### PR TITLE
Include Transaction type field

### DIFF
--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -33,7 +33,7 @@ pub struct Transaction {
     pub confirmations_required: Option<usize>,
     pub confirmations: Option<Vec<Confirmation>>,
     pub signatures: Option<String>,
-    pub tx_type: TransactionType,
+    pub tx_type: Option<TransactionType>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -1,4 +1,4 @@
-use super::super::commons::Operation;
+use super::super::commons::{Operation, TransactionType};
 use chrono::{DateTime, Utc};
 use ethereum_types::{Address, H256};
 use serde::{Deserialize, Serialize};
@@ -6,33 +6,34 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
-    pub safe: Address,
+    pub safe: Option<Address>,
     pub to: Address,
-    pub value: String,
+    pub value: Option<String>,
     pub data: Option<String>,
-    pub operation: Operation,
-    pub gas_token: Address,
-    pub safe_tx_gas: usize,
-    pub base_gas: usize,
-    pub gas_price: String,
-    pub refund_receiver: Address,
-    pub nonce: usize,
+    pub operation: Option<Operation>,
+    pub gas_token: Option<Address>,
+    pub safe_tx_gas: Option<usize>,
+    pub base_gas: Option<usize>,
+    pub gas_price: Option<String>,
+    pub refund_receiver: Option<Address>,
+    pub nonce: Option<usize>,
     pub execution_date: Option<DateTime<Utc>>,
     pub submission_date: Option<DateTime<Utc>>,
     pub modified: Option<DateTime<Utc>>,
     pub block_number: Option<usize>,
     pub transaction_hash: Option<H256>,
-    pub safe_tx_hash: H256,
+    pub safe_tx_hash: Option<H256>,
     pub executor: Option<Address>,
-    pub is_executed: bool,
+    pub is_executed: Option<bool>,
     pub is_successful: Option<bool>,
     pub eth_gas_price: Option<String>,
     pub gas_used: Option<usize>,
     pub fee: Option<String>,
     pub origin: Option<Address>,
     pub confirmations_required: Option<usize>,
-    pub confirmations: Vec<Confirmation>,
+    pub confirmations: Option<Vec<Confirmation>>,
     pub signatures: Option<String>,
+    pub tx_type: TransactionType,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/models/commons.rs
+++ b/src/models/commons.rs
@@ -14,6 +14,7 @@ pub enum TransactionType {
     MultisigTransaction,
     EthereumTransaction,
     ModuleTransaction,
+    Unknown
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/models/commons.rs
+++ b/src/models/commons.rs
@@ -1,8 +1,26 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum Operation {
     CALL = 0,
     DELEGATE = 1,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionType {
+    MultisigTransaction,
+    EthereumTransaction,
+    ModuleTransaction,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Page<T> {
+    pub count: usize,
+    pub next: Option<String>,
+    pub previous: Option<String>,
+    pub results: Vec<T>,
 }

--- a/src/models/converters/transactions.rs
+++ b/src/models/converters/transactions.rs
@@ -1,12 +1,14 @@
+extern crate chrono;
 use super::super::backend::transactions::Transaction as TransactionDto;
 use super::super::service::transactions::Transaction;
+use chrono::Utc;
 
 impl TransactionDto {
-
     pub fn to_transaction(&self) -> Transaction {
         Transaction {
             to: self.to,
-            timestamp: self.submission_date.unwrap(),
+            timestamp: self.submission_date.unwrap_or(Utc::now()), // TODO unacceptable default value
+            transaction_type: self.tx_type,
         }
     }
 }

--- a/src/models/converters/transactions.rs
+++ b/src/models/converters/transactions.rs
@@ -2,13 +2,14 @@ extern crate chrono;
 use super::super::backend::transactions::Transaction as TransactionDto;
 use super::super::service::transactions::Transaction;
 use chrono::Utc;
+use crate::models::commons::TransactionType;
 
 impl TransactionDto {
     pub fn to_transaction(&self) -> Transaction {
         Transaction {
             to: self.to,
             timestamp: self.submission_date.unwrap_or(Utc::now()), // TODO unacceptable default value
-            transaction_type: self.tx_type,
+            transaction_type: self.tx_type.unwrap_or(TransactionType::Unknown),
         }
     }
 }

--- a/src/models/service/transactions.rs
+++ b/src/models/service/transactions.rs
@@ -1,9 +1,11 @@
 use ethereum_types::{Address, H256, U256};
 use serde::Serialize;
 use chrono::{DateTime, Utc};
+use super::super::commons::TransactionType;
 
 #[derive(Serialize, Debug)]
 pub struct Transaction {
     pub to: Address,
     pub timestamp: DateTime<Utc>,
+    pub transaction_type: TransactionType,
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,5 +5,5 @@ use rocket::Route;
 mod transactions;
 
 pub fn transaction_routes() -> Vec<Route> {
-    routes![transactions::details, transactions::about]
+    routes![transactions::details, transactions::about, transactions::all]
 }

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -1,6 +1,11 @@
 use crate::services::transactions;
 
-#[get("/transactions/<tx_hash>")]
+#[get("/transactions/<safe_address>")]
+pub fn all(safe_address: String) -> String {
+    transactions::get_all_transactions(safe_address)
+}
+
+#[get("/transaction/<tx_hash>")]
 pub fn details(tx_hash: String) -> String {
     transactions::get_transactions_details(tx_hash)
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -5,9 +5,6 @@ pub mod transactions;
 
 fn base_transaction_service_url() -> String {
     //TODO implement logic for selecting network mainnet/rinkeby
-    String::from("https://safe-transaction.rinkeby.gnosis.io/api/v1")
-}
-
-fn base_4byte_service_url() -> String {
-    String::from("https://www.4byte.directory/api/v1")
+    // String::from("https://safe-transaction.rinkeby.gnosis.io/api/v1")
+    String::from("https://safe-transaction.staging.gnosisdev.com/api/v1")
 }

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -5,6 +5,7 @@ use crate::models::backend::about::About;
 use crate::models::backend::transactions::Transaction as TransactionDto;
 use crate::models::service::transactions::Transaction;
 use crate::models::converters::transactions;
+use crate::models::commons::Page;
 use reqwest::Url;
 
 pub fn get_about() -> String {
@@ -25,10 +26,25 @@ pub fn get_transactions_details(tx_hash: String) -> String {
         tx_hash
     );
     let url = Url::parse(&url_string).unwrap();
-    println!("{}", &url);
     let body = reqwest::blocking::get(url).unwrap().text().unwrap();
-    println!("{:#}", body);
     let transaction: TransactionDto = serde_json::from_str(&body).unwrap();
     let transaction: Transaction = transaction.to_transaction();
+    serde_json::to_string(&transaction).unwrap()
+}
+
+
+pub fn get_all_transactions(safe_address: String) -> String {
+    let url_string = format!(
+        "{}/safes/{}/all-transactions",
+        base_transaction_service_url(),
+        safe_address
+    );
+    let url = Url::parse(&url_string).unwrap();
+    let body = reqwest::blocking::get(url).unwrap().text().unwrap();
+    println!("{:#?}", body);
+    let transactions: Page<TransactionDto> = serde_json::from_str(&body).unwrap();
+    let transaction: Vec<Transaction> = transactions.results.into_iter()
+        .map(|transaction| transaction.to_transaction())
+        .collect();
     serde_json::to_string(&transaction).unwrap()
 }


### PR DESCRIPTION
- Added `/transactions/{safe_id}` endpoint forwarding to `/safe/{safe_id}/all-transactions`
- Pointing transaction backend to staging/rinkeby
- Added field to mapping method and made everything option for objects coming from the transaction service