### PR TITLE
Closes #29 and Closes #28: Add info provider for safes and tokens

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -38,12 +38,12 @@ impl ServiceCache {
         }
     }
 
-    pub fn request_cached(&self, client: &reqwest::blocking::Client, key: &String, url: &String, timeout: usize) -> Result<String>  {
-        let data: String = match self.fetch(&key) {
+    pub fn request_cached(&self, client: &reqwest::blocking::Client, url: &String, timeout: usize) -> Result<String>  {
+        let data: String = match self.fetch(&url) {
             Some(cached) => cached,
             None => {
                 let response = client.get(url).send()?.text()?;
-                self.create(&key, &response, timeout);
+                self.create(&url, &response, timeout);
                 response
             }
         };

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,4 +37,16 @@ impl ServiceCache {
             }
         }
     }
+
+    pub fn request_cached(&self, client: &reqwest::blocking::Client, key: &String, url: &String, timeout: usize) -> Result<String>  {
+        let data: String = match self.fetch(&key) {
+            Some(cached) => cached,
+            None => {
+                let response = client.get(url).send()?.text()?;
+                self.create(&key, &response, timeout);
+                response
+            }
+        };
+        Ok(data)
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+pub fn base_transaction_service_url() -> String {
+    format!("{}{}", env::var("TRANSACTION_SERVICE_URL").unwrap(), "/api/v1")
+}
+
+fn usize_with_default(key: &str, default: usize) -> usize {
+    match env::var(key) {
+        Ok(value) => value.parse().unwrap(),
+        Err(_) => default
+    }
+}
+
+pub fn token_info_cache_duration() -> usize {
+    usize_with_default("TOKEN_INFO_CACHE_DURATION", 60 * 15)
+}
+
+pub fn safe_info_cache_duration() -> usize {
+    usize_with_default("SAFE_INFO_CACHE_DURATION", 60 * 15)
+}
+
+pub fn request_cache_duration() -> usize {
+    usize_with_default("REQUEST_CACHE_DURATION", 60 * 15)
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod routes;
 mod services;
 mod models;
 mod utils;
+mod providers;
 
 use cache::{ServiceCache};
 use utils::cors::{CORS};

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,15 @@ mod models;
 mod utils;
 
 use cache::{ServiceCache};
+use utils::cors::{CORS};
 use routes::transaction_routes;
 use crate::routes::error_catchers;
 
 fn main() {
     rocket::ignite()
         .mount("/", transaction_routes())
+        .manage(reqwest::blocking::Client::new())
+        .attach(CORS())
         .attach(ServiceCache::fairing())
         .register(error_catchers())
         .launch();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,25 @@ extern crate rocket;
 #[macro_use]
 extern crate rocket_contrib;
 
-#[macro_use]
-extern crate dotenv_codegen;
+extern crate dotenv;
 
 mod cache;
+mod config;
 mod routes;
 mod services;
 mod models;
 mod utils;
 mod providers;
 
+use dotenv::dotenv;
 use cache::{ServiceCache};
 use utils::cors::{CORS};
 use routes::transaction_routes;
 use crate::routes::error_catchers;
 
 fn main() {
+    dotenv().ok();
+
     rocket::ignite()
         .mount("/", transaction_routes())
         .manage(reqwest::blocking::Client::new())

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -5,20 +5,23 @@ use serde_json;
 use serde::{Deserialize, Serialize};
 use anyhow::Result;
 use ethereum_types::{Address};
+use std::collections::HashMap;
 
 pub struct InfoProvider<'p> {
     client: &'p reqwest::blocking::Client,
-    cache: ServiceCache
+    cache: ServiceCache,
+    safe_cache: HashMap<String, SafeInfo>,
+    token_cache: HashMap<String, TokenInfo>
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SafeInfo {
     nonce: u64,
     threshold: u64,
     owners: Vec<Address>
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TokenInfo {
     token_type: String,
     decimals: u64,
@@ -27,31 +30,49 @@ pub struct TokenInfo {
     logo_uri: Option<String>
 }
 
+macro_rules! with_in_memory_cache {
+    ($this:ident.$cache:ident, $key:expr, $factory:expr) => {
+        match $this.$cache.get($key) {
+            Some(value) => Ok(value.clone()),
+            None => {
+                let value = $factory($key)?;
+                $this.$cache.insert($key.to_owned(), value.clone());
+                Ok(value)
+            }
+        }
+    }
+}
+
 impl InfoProvider<'_> {
     pub fn new<'p>(context: &'p Context) -> InfoProvider<'p> {
         let provider = InfoProvider {
-            client: context.client(), cache: context.cache()
+            client: context.client(), cache: context.cache(), 
+            safe_cache: HashMap::new(), token_cache: HashMap::new(), 
         };
         return provider;
     }
 
-    pub fn safe_info(&self, safe: &String) -> Result<SafeInfo> {
+    pub fn safe_info(&mut self, safe: &String) -> Result<SafeInfo> {
         let url = format!(
             "{}/safes/{}/",
             base_transaction_service_url(),
             safe
         );
-        let data = self.cache.request_cached(self.client, &url, 60*15)?;
-        Ok(serde_json::from_str(&data)?)
+        with_in_memory_cache!(self.safe_cache, &url, |url: &String| -> Result<SafeInfo> {
+            let data = self.cache.request_cached(self.client, &url, 60*15)?;
+            Ok(serde_json::from_str(&data)?)
+        })
     }
 
-    pub fn token_info(&self, token: &String) -> Result<TokenInfo> {
+    pub fn token_info(&mut self, token: &String) -> Result<TokenInfo> {
         let url = format!(
             "{}/tokens/{}/",
             base_transaction_service_url(),
             token
         );
-        let data = self.cache.request_cached(self.client, &url, 60*15)?;
-        Ok(serde_json::from_str(&data)?)
+        with_in_memory_cache!(self.token_cache, &url, |url: &String| -> Result<TokenInfo> {
+            let data = self.cache.request_cached(self.client, &url, 60*15)?;
+            Ok(serde_json::from_str(&data)?)
+        })
     }
 }

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -1,0 +1,59 @@
+use crate::services::base_transaction_service_url;
+use crate::utils::context::{Context};
+use crate::cache::{ServiceCache};
+use serde_json;
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
+use ethereum_types::{Address};
+
+pub struct InfoProvider<'p> {
+    client: &'p reqwest::blocking::Client,
+    cache: ServiceCache
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SafeInfo {
+    nonce: u64,
+    threshold: u64,
+    owners: Vec<Address>
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TokenInfo {
+    token_type: String,
+    decimals: u64,
+    symbol: String,
+    name: String,
+    logo_uri: Option<String>
+}
+
+impl InfoProvider<'_> {
+    pub fn new<'p>(context: &'p Context) -> InfoProvider<'p> {
+        let provider = InfoProvider {
+            client: context.client(), cache: context.cache()
+        };
+        return provider;
+    }
+
+    pub fn safe_info(&self, safe: &String) -> Result<SafeInfo> {
+        let key = format!("safe_info_{}", safe);
+        let url = format!(
+            "{}/safes/{}/",
+            base_transaction_service_url(),
+            safe
+        );
+        let data = self.cache.request_cached(self.client, &key, &url, 60*15)?;
+        Ok(serde_json::from_str(&data)?)
+    }
+
+    pub fn token_info(&self, token: &String) -> Result<TokenInfo> {
+        let key = format!("token_info_{}", token);
+        let url = format!(
+            "{}/tokens/{}/",
+            base_transaction_service_url(),
+            token
+        );
+        let data = self.cache.request_cached(self.client, &key, &url, 60*15)?;
+        Ok(serde_json::from_str(&data)?)
+    }
+}

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -1,4 +1,4 @@
-use crate::services::base_transaction_service_url;
+use crate::config::{base_transaction_service_url, safe_info_cache_duration, token_info_cache_duration};
 use crate::utils::context::{Context};
 use crate::cache::{ServiceCache};
 use serde_json;
@@ -59,7 +59,7 @@ impl InfoProvider<'_> {
             safe
         );
         with_in_memory_cache!(self.safe_cache, &url, |url: &String| -> Result<SafeInfo> {
-            let data = self.cache.request_cached(self.client, &url, 60*15)?;
+            let data = self.cache.request_cached(self.client, &url, safe_info_cache_duration())?;
             Ok(serde_json::from_str(&data)?)
         })
     }
@@ -71,7 +71,7 @@ impl InfoProvider<'_> {
             token
         );
         with_in_memory_cache!(self.token_cache, &url, |url: &String| -> Result<TokenInfo> {
-            let data = self.cache.request_cached(self.client, &url, 60*15)?;
+            let data = self.cache.request_cached(self.client, &url, token_info_cache_duration())?;
             Ok(serde_json::from_str(&data)?)
         })
     }

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -36,24 +36,22 @@ impl InfoProvider<'_> {
     }
 
     pub fn safe_info(&self, safe: &String) -> Result<SafeInfo> {
-        let key = format!("safe_info_{}", safe);
         let url = format!(
             "{}/safes/{}/",
             base_transaction_service_url(),
             safe
         );
-        let data = self.cache.request_cached(self.client, &key, &url, 60*15)?;
+        let data = self.cache.request_cached(self.client, &url, 60*15)?;
         Ok(serde_json::from_str(&data)?)
     }
 
     pub fn token_info(&self, token: &String) -> Result<TokenInfo> {
-        let key = format!("token_info_{}", token);
         let url = format!(
             "{}/tokens/{}/",
             base_transaction_service_url(),
             token
         );
-        let data = self.cache.request_cached(self.client, &key, &url, 60*15)?;
+        let data = self.cache.request_cached(self.client, &url, 60*15)?;
         Ok(serde_json::from_str(&data)?)
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,0 +1,1 @@
+pub mod info;

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -1,3 +1,4 @@
+use crate::config::request_cache_duration
 use crate::utils::context::Context;
 use crate::services::transactions;
 use rocket::response::content;
@@ -5,7 +6,7 @@ use anyhow::Result;
 
 #[get("/transactions/<safe_address>")]
 pub fn all(context: Context, safe_address: String) -> Result<content::Json<String>> {
-    context.cache().cache_resp(&safe_address, 60 * 2, || {
+    context.cache().cache_resp(&safe_address, request_cache_duration(), || {
         transactions::get_all_transactions(&context, &safe_address)
     })
 }

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -1,12 +1,12 @@
-use crate::cache::ServiceCache;
+use crate::utils::context::Context;
 use crate::services::transactions;
 use rocket::response::content;
 use anyhow::Result;
 
 #[get("/transactions/<safe_address>")]
-pub fn all(cache: ServiceCache, safe_address: String) -> Result<content::Json<String>> {
-    cache.cache_resp(&safe_address, 60 * 2, || {
-        transactions::get_all_transactions(&safe_address)
+pub fn all(context: Context, safe_address: String) -> Result<content::Json<String>> {
+    context.cache().cache_resp(&safe_address, 60 * 2, || {
+        transactions::get_all_transactions(&context, &safe_address)
     })
 }
 
@@ -16,6 +16,6 @@ pub fn details(tx_hash: String) -> content::Json<String> {
 }
 
 #[get("/transactions/about")]
-pub fn about(cache: ServiceCache) -> Result<content::Json<String>> {
-    cache.cache_resp(&String::from("about_page"), 60 * 200, transactions::get_about)
+pub fn about(context: Context) -> Result<content::Json<String>> {
+    context.cache().cache_resp(&String::from("about_page"), 60 * 200, transactions::get_about)
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,5 +1,5 @@
 pub mod transactions;
 
-fn base_transaction_service_url() -> String {
+pub fn base_transaction_service_url() -> String {
     format!("{}{}", dotenv!("TRANSACTION_SERVICE_URL"), "/api/v1")
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,5 +1,1 @@
 pub mod transactions;
-
-pub fn base_transaction_service_url() -> String {
-    format!("{}{}", dotenv!("TRANSACTION_SERVICE_URL"), "/api/v1")
-}

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -1,6 +1,6 @@
 extern crate reqwest;
 
-use super::base_transaction_service_url;
+use crate::config::{base_transaction_service_url, request_cache_duration};
 use crate::models::backend::about::About;
 use crate::models::backend::transactions::Transaction as TransactionDto;
 use crate::models::service::transactions::Transaction as ServiceTransaction;
@@ -45,7 +45,7 @@ pub fn get_all_transactions(context: &Context, safe_address: &String) -> Result<
         base_transaction_service_url(),
         safe_address
     );
-    let body = context.cache().request_cached(&context.client(), &url, 15)?;
+    let body = context.cache().request_cached(&context.client(), &url, request_cache_duration())?;
     println!("request URL: {}", &url);
     println!("{:#?}", body);
     let transactions: Page<TransactionDto> = serde_json::from_str(&body)?;

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -38,7 +38,8 @@ pub fn get_transactions_details(tx_hash: String) -> String {
 
 
 pub fn get_all_transactions(context: &Context, safe_address: &String) -> Result<Vec<ServiceTransaction>> {
-    let info_provider = InfoProvider::new(context);
+    let mut info_provider = InfoProvider::new(context);
+    info_provider.safe_info(safe_address);
     let url_string = format!(
         "{}/safes/{}/all-transactions",
         base_transaction_service_url(),

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -6,6 +6,7 @@ use crate::models::backend::transactions::Transaction as TransactionDto;
 use crate::models::service::transactions::Transaction as ServiceTransaction;
 use crate::models::commons::Page;
 use crate::utils::context::Context;
+use crate::providers::info::InfoProvider;
 use reqwest::Url;
 use anyhow::Result;
 
@@ -37,6 +38,7 @@ pub fn get_transactions_details(tx_hash: String) -> String {
 
 
 pub fn get_all_transactions(context: &Context, safe_address: &String) -> Result<Vec<ServiceTransaction>> {
+    let info_provider = InfoProvider::new(context);
     let url_string = format!(
         "{}/safes/{}/all-transactions",
         base_transaction_service_url(),

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -5,6 +5,7 @@ use crate::models::backend::about::About;
 use crate::models::backend::transactions::Transaction as TransactionDto;
 use crate::models::service::transactions::Transaction as ServiceTransaction;
 use crate::models::commons::Page;
+use crate::utils::context::Context;
 use reqwest::Url;
 use anyhow::Result;
 
@@ -35,14 +36,14 @@ pub fn get_transactions_details(tx_hash: String) -> String {
 }
 
 
-pub fn get_all_transactions(safe_address: &String) -> Result<Vec<ServiceTransaction>> {
+pub fn get_all_transactions(context: &Context, safe_address: &String) -> Result<Vec<ServiceTransaction>> {
     let url_string = format!(
         "{}/safes/{}/all-transactions",
         base_transaction_service_url(),
         safe_address
     );
     let url = Url::parse(&url_string)?;
-    let body = reqwest::blocking::get(url)?.text()?;
+    let body = context.client().get(url).send()?.text()?;
     println!("request URL: {}", &url_string);
     println!("{:#?}", body);
     let transactions: Page<TransactionDto> = serde_json::from_str(&body)?;

--- a/src/services/transactions.rs
+++ b/src/services/transactions.rs
@@ -40,14 +40,13 @@ pub fn get_transactions_details(tx_hash: String) -> String {
 pub fn get_all_transactions(context: &Context, safe_address: &String) -> Result<Vec<ServiceTransaction>> {
     let mut info_provider = InfoProvider::new(context);
     info_provider.safe_info(safe_address);
-    let url_string = format!(
+    let url = format!(
         "{}/safes/{}/all-transactions",
         base_transaction_service_url(),
         safe_address
     );
-    let url = Url::parse(&url_string)?;
-    let body = context.client().get(url).send()?.text()?;
-    println!("request URL: {}", &url_string);
+    let body = context.cache().request_cached(&context.client(), &url, 15)?;
+    println!("request URL: {}", &url);
     println!("{:#?}", body);
     let transactions: Page<TransactionDto> = serde_json::from_str(&body)?;
     let transactions: Vec<ServiceTransaction> = transactions.results.into_iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,9 @@
 use crate::models::commons::DataDecoded;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
+pub mod cors;
+pub mod context;
 
 //TODO think of a better impl, using enums as per Nick's suggestion
 pub const ERC20_TRANSFER_METHODS: &[&str] = &["transfer", "transferFrom"];
@@ -37,4 +41,10 @@ impl DataDecoded {
     pub fn is_settings_change(&self) -> bool {
         SETTINGS_CHANGE_METHODS.iter().any(|&value| value == self.method)
     }
+}
+
+pub fn hex_hash<T: Hash>(t: &T) -> String {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    format!("{:#x}", s.finish())
 }

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -5,7 +5,7 @@ use rocket::State;
 use crate::cache::{ServiceCache};
 
 pub struct Context<'a, 'r> {
-    request: &'a Request<'r>,
+    request: &'a Request<'r>
 }
 
 impl<'a, 'r> Context<'a, 'r> {

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -1,0 +1,31 @@
+use rocket::request::{self, FromRequest, Request};
+use rocket::Outcome;
+use rocket::State;
+
+use crate::cache::{ServiceCache};
+
+pub struct Context<'a, 'r> {
+    request: &'a Request<'r>,
+}
+
+impl<'a, 'r> Context<'a, 'r> {
+    fn get<T: FromRequest<'a, 'r>>(&self) -> T {
+        self.request.guard::<T>().unwrap()
+    }
+
+    pub fn client(&self) -> &'r reqwest::blocking::Client {
+        self.get::<State<reqwest::blocking::Client>>().inner()
+    }
+
+    pub fn cache(&self) -> ServiceCache {
+        self.get::<ServiceCache>()
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Context<'a, 'r> {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
+        return Outcome::Success(Context { request });
+    }
+}

--- a/src/utils/cors.rs
+++ b/src/utils/cors.rs
@@ -1,0 +1,30 @@
+use rocket::{Request, Response};
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::http::{Header, ContentType, Method};
+use std::io::Cursor;
+
+pub struct CORS();
+
+impl Fairing for CORS {
+    fn info(&self) -> Info {
+        Info {
+            name: "Add CORS headers to requests",
+            kind: Kind::Response
+        }
+    }
+
+    fn on_response(&self, request: &Request, response: &mut Response) {
+        // TODO https://github.com/lawliet89/rocket_cors/blob/master/examples/fairing.rs
+        if request.method() == Method::Options || response.content_type() == Some(ContentType::JSON) {
+            response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
+            response.set_header(Header::new("Access-Control-Allow-Methods", "POST, GET, OPTIONS"));
+            response.set_header(Header::new("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization"));
+            response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
+        }
+
+        if request.method() == Method::Options {
+            response.set_header(ContentType::Plain);
+            response.set_sized_body(Cursor::new(""));
+        }
+    }
+}


### PR DESCRIPTION
Closes #29: Add provider to load token info
Closes #28: Add provider to load safe info

- Added redis cache
- Added in-memory cache that is used while processing one request
- Added config module
- Added context request guard for easy access to shared client and cache wrapper