### PR TITLE
Closes #36 fix for missing token info

### DIFF
--- a/src/models/backend/transfers.rs
+++ b/src/models/backend/transfers.rs
@@ -23,7 +23,7 @@ pub struct Erc721Transfer {
     pub to: String,
     pub token_id: String,
     pub token_address: String,
-    pub token_info: Erc721TokenInfo,
+    pub token_info: Option<Erc721TokenInfo>,
     pub from: String,
 }
 
@@ -43,7 +43,7 @@ pub struct Erc20Transfer {
     pub to: String,
     pub value: String,
     pub token_address: String,
-    pub token_info: Erc20TokenInfo,
+    pub token_info: Option<Erc20TokenInfo>,
     pub from: String,
 }
 

--- a/src/models/converters/transactions.rs
+++ b/src/models/converters/transactions.rs
@@ -27,10 +27,10 @@ impl MultisigTransaction {
             id: String::from("multisig_<something_else_eventually>"),
             timestamp: self.execution_date.unwrap_or(self.submission_date).timestamp_millis(),
             tx_status: self.map_status(&safe_info),
-            execution_info: Some(ExecutionInfo{
+            execution_info: Some(ExecutionInfo {
                 nonce: self.nonce,
                 confirmations_submitted: self.confirmation_count(),
-                confirmations_required: self.confirmation_required(&safe_info)
+                confirmations_required: self.confirmation_required(&safe_info),
             }),
             tx_info: self.transaction_info(info_provider),
         }))
@@ -115,10 +115,10 @@ impl MultisigTransaction {
             ).unwrap_or(String::from("0x0")),
             transfer_info: TransferInfo::Erc20 {
                 token_address: token.address.to_owned(),
-                token_name: token.name.to_owned(),
-                token_symbol: token.symbol.to_owned(),
                 logo_uri: token.logo_uri.to_owned(),
-                decimals: token.decimals,
+                token_name: Some(token.name.to_owned()),
+                token_symbol: Some(token.symbol.to_owned()),
+                decimals: Some(token.decimals),
                 value: self.data_decoded.as_ref().and_then(
                     |it| it.get_parameter_value("value")
                 ).unwrap_or(String::from("0")),
@@ -137,8 +137,8 @@ impl MultisigTransaction {
             ).unwrap_or(String::from("0x0")),
             transfer_info: TransferInfo::Erc721 {
                 token_address: token.address.to_owned(),
-                token_name: token.name.to_owned(),
-                token_symbol: token.symbol.to_owned(),
+                token_name: Some(token.name.to_owned()),
+                token_symbol: Some(token.symbol.to_owned()),
                 token_id: self.data_decoded.as_ref().and_then(
                     |it| match it.get_parameter_value("tokenId") {
                         Some(e) => Some(e),

--- a/src/models/converters/transfers.rs
+++ b/src/models/converters/transfers.rs
@@ -20,11 +20,11 @@ impl Erc20Transfer {
             recipient: self.to.to_owned(),
             transfer_info: TransferInfo::Erc20 {
                 token_address: self.token_address.clone(),
-                token_name: self.token_info.name.clone(),
-                token_symbol: self.token_info.symbol.clone(),
-                logo_uri: self.token_info.logo_uri.clone(),
-                decimals: self.token_info.decimals,
                 value: self.value.clone(),
+                token_name: self.token_info.as_ref().map(|it| it.name.to_owned()),
+                decimals: self.token_info.as_ref().map(|it| it.decimals.to_owned()),
+                logo_uri: self.token_info.as_ref().and_then(|it| it.logo_uri.to_owned()),
+                token_symbol: self.token_info.as_ref().map(|it| it.symbol.to_owned()),
             },
         }
     }
@@ -38,9 +38,9 @@ impl Erc721Transfer {
             transfer_info: TransferInfo::Erc721 {
                 token_address: self.token_address.clone(),
                 token_id: self.token_id.clone(),
-                token_name: self.token_info.name.clone(),
-                token_symbol: self.token_info.symbol.clone(),
-                logo_uri: self.token_info.logo_uri.clone(),
+                token_name: self.token_info.as_ref().map(|it| it.name.to_owned()),
+                token_symbol: self.token_info.as_ref().map(|it| it.symbol.to_owned()),
+                logo_uri: self.token_info.as_ref().and_then(|it| it.logo_uri.to_owned()),
             },
         }
     }

--- a/src/models/service/transactions.rs
+++ b/src/models/service/transactions.rs
@@ -51,17 +51,17 @@ pub struct Transfer {
 pub enum TransferInfo {
     Erc20 {
         token_address: String,
-        token_name: String,
-        token_symbol: String,
+        token_name: Option<String>,
+        token_symbol: Option<String>,
         logo_uri: Option<String>,
-        decimals: u64,
+        decimals: Option<u64>,
         value: String,
     },
     Erc721 {
         token_address: String,
-        token_name: String,
-        token_symbol: String,
         token_id: String,
+        token_name: Option<String>,
+        token_symbol: Option<String>,
         logo_uri: Option<String>,
     },
     Ether {


### PR DESCRIPTION
Closes #36
- Made certain fields nullable when token info is not found in the backend's token endpoint