### PR TITLE
Closes #45 Corrected casing for fields in transfers and status enum

### DIFF
--- a/src/models/converters/transactions.rs
+++ b/src/models/converters/transactions.rs
@@ -1,7 +1,7 @@
 extern crate chrono;
 
 use super::super::backend::transactions::Transaction as TransactionDto;
-use crate::models::service::transactions::{Transaction, SettingsChange, Transfer, Custom, TransferInfo, TransactionStatus, TransactionInfo, ExecutionInfo};
+use crate::models::service::transactions::{Transaction, SettingsChange, Transfer, Custom, TransferInfo, TransactionStatus, TransactionInfo, ExecutionInfo, Erc20Transfer, Erc721Transfer, EtherTransfer};
 use crate::models::backend::transactions::{MultisigTransaction, ModuleTransaction, EthereumTransaction};
 use crate::models::commons::Operation;
 use crate::providers::info::{InfoProvider, SafeInfo, TokenInfo, TokenType};
@@ -113,16 +113,17 @@ impl MultisigTransaction {
             recipient: self.data_decoded.as_ref().and_then(
                 |it| it.get_parameter_value("to")
             ).unwrap_or(String::from("0x0")),
-            transfer_info: TransferInfo::Erc20 {
-                token_address: token.address.to_owned(),
-                logo_uri: token.logo_uri.to_owned(),
-                token_name: Some(token.name.to_owned()),
-                token_symbol: Some(token.symbol.to_owned()),
-                decimals: Some(token.decimals),
-                value: self.data_decoded.as_ref().and_then(
-                    |it| it.get_parameter_value("value")
-                ).unwrap_or(String::from("0")),
-            },
+            transfer_info: TransferInfo::Erc20(
+                Erc20Transfer {
+                    token_address: token.address.to_owned(),
+                    logo_uri: token.logo_uri.to_owned(),
+                    token_name: Some(token.name.to_owned()),
+                    token_symbol: Some(token.symbol.to_owned()),
+                    decimals: Some(token.decimals),
+                    value: self.data_decoded.as_ref().and_then(
+                        |it| it.get_parameter_value("value")
+                    ).unwrap_or(String::from("0")),
+                }),
         }
     }
 
@@ -135,18 +136,19 @@ impl MultisigTransaction {
                     None => it.get_parameter_value("to")
                 }
             ).unwrap_or(String::from("0x0")),
-            transfer_info: TransferInfo::Erc721 {
-                token_address: token.address.to_owned(),
-                token_name: Some(token.name.to_owned()),
-                token_symbol: Some(token.symbol.to_owned()),
-                token_id: self.data_decoded.as_ref().and_then(
-                    |it| match it.get_parameter_value("tokenId") {
-                        Some(e) => Some(e),
-                        None => it.get_parameter_value("value")
-                    }
-                ).unwrap_or(String::from("0")),
-                logo_uri: token.logo_uri.to_owned(),
-            },
+            transfer_info: TransferInfo::Erc721(
+                Erc721Transfer {
+                    token_address: token.address.to_owned(),
+                    token_name: Some(token.name.to_owned()),
+                    token_symbol: Some(token.symbol.to_owned()),
+                    token_id: self.data_decoded.as_ref().and_then(
+                        |it| match it.get_parameter_value("tokenId") {
+                            Some(e) => Some(e),
+                            None => it.get_parameter_value("value")
+                        }
+                    ).unwrap_or(String::from("0")),
+                    logo_uri: token.logo_uri.to_owned(),
+                }),
         }
     }
 
@@ -154,9 +156,10 @@ impl MultisigTransaction {
         Transfer {
             sender: self.safe.to_owned(),
             recipient: self.to.to_owned(),
-            transfer_info: TransferInfo::Ether {
-                value: self.value.as_ref().unwrap().to_string(),
-            },
+            transfer_info: TransferInfo::Ether(
+                EtherTransfer {
+                    value: self.value.as_ref().unwrap().to_string(),
+                }),
         }
     }
 

--- a/src/models/converters/transfers.rs
+++ b/src/models/converters/transfers.rs
@@ -1,6 +1,6 @@
-use crate::models::service::transactions::{TransferInfo, TransactionInfo};
+use crate::models::service::transactions::{TransferInfo, TransactionInfo, Erc20Transfer, Erc721Transfer, EtherTransfer};
 use crate::models::service::transactions::Transfer as ServiceTransfer;
-use crate::models::backend::transfers::{Transfer as TransferDto, Erc20Transfer, Erc721Transfer, EtherTransfer};
+use crate::models::backend::transfers::{Transfer as TransferDto, Erc20Transfer as Erc20TransferDto, Erc721Transfer as Erc721TransferDto, EtherTransfer as EtherTransferDto};
 
 impl TransferDto {
     pub fn to_transfer(&self) -> TransactionInfo {
@@ -13,47 +13,47 @@ impl TransferDto {
     }
 }
 
-impl Erc20Transfer {
+impl Erc20TransferDto {
     fn to_transfer_transaction(&self) -> ServiceTransfer {
         ServiceTransfer {
             sender: self.from.to_owned(),
             recipient: self.to.to_owned(),
-            transfer_info: TransferInfo::Erc20 {
+            transfer_info: TransferInfo::Erc20(Erc20Transfer {
                 token_address: self.token_address.clone(),
                 value: self.value.clone(),
                 token_name: self.token_info.as_ref().map(|it| it.name.to_owned()),
                 decimals: self.token_info.as_ref().map(|it| it.decimals.to_owned()),
                 logo_uri: self.token_info.as_ref().and_then(|it| it.logo_uri.to_owned()),
                 token_symbol: self.token_info.as_ref().map(|it| it.symbol.to_owned()),
-            },
+            }),
         }
     }
 }
 
-impl Erc721Transfer {
+impl Erc721TransferDto {
     fn to_transfer_transaction(&self) -> ServiceTransfer {
         ServiceTransfer {
             sender: self.from.to_owned(),
             recipient: self.to.to_owned(),
-            transfer_info: TransferInfo::Erc721 {
+            transfer_info: TransferInfo::Erc721(Erc721Transfer {
                 token_address: self.token_address.clone(),
                 token_id: self.token_id.clone(),
                 token_name: self.token_info.as_ref().map(|it| it.name.to_owned()),
                 token_symbol: self.token_info.as_ref().map(|it| it.symbol.to_owned()),
                 logo_uri: self.token_info.as_ref().and_then(|it| it.logo_uri.to_owned()),
-            },
+            }),
         }
     }
 }
 
-impl EtherTransfer {
+impl EtherTransferDto {
     fn to_transfer_transaction(&self) -> ServiceTransfer {
         ServiceTransfer {
             sender: self.from.to_owned(),
             recipient: self.to.to_owned(),
-            transfer_info: TransferInfo::Ether {
+            transfer_info: TransferInfo::Ether(EtherTransfer {
                 value: self.value.clone()
-            },
+            }),
         }
     }
 }

--- a/src/models/service/transactions.rs
+++ b/src/models/service/transactions.rs
@@ -12,7 +12,6 @@ pub struct Transaction {
 }
 
 #[derive(Serialize, Debug)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionStatus {
     AwaitingConfirmations,
     AwaitingExecution,
@@ -49,24 +48,36 @@ pub struct Transfer {
 #[derive(Serialize, Debug)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransferInfo {
-    Erc20 {
-        token_address: String,
-        token_name: Option<String>,
-        token_symbol: Option<String>,
-        logo_uri: Option<String>,
-        decimals: Option<u64>,
-        value: String,
-    },
-    Erc721 {
-        token_address: String,
-        token_id: String,
-        token_name: Option<String>,
-        token_symbol: Option<String>,
-        logo_uri: Option<String>,
-    },
-    Ether {
-        value: String,
-    },
+    Erc20(Erc20Transfer),
+    Erc721(Erc721Transfer),
+    Ether(EtherTransfer),
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Erc20Transfer {
+    pub token_address: String,
+    pub token_name: Option<String>,
+    pub token_symbol: Option<String>,
+    pub logo_uri: Option<String>,
+    pub decimals: Option<u64>,
+    pub value: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Erc721Transfer {
+    pub token_address: String,
+    pub token_id: String,
+    pub token_name: Option<String>,
+    pub token_symbol: Option<String>,
+    pub logo_uri: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EtherTransfer {
+    pub value: String,
 }
 
 #[derive(Serialize, Debug)]


### PR DESCRIPTION
Closes #45 

- Fields for `TransferInfo` are now camelCased
- Status enum no longer changed