### PR TITLE
Closes #56 Creation transaction

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,7 @@ macro_rules! concat_parts {
         // `stringify!` will convert the expression *as it is* into a string.
         format!(
             "{}{}",
-            ID_SEPARATOR,
+            $crate::models::service::transactions::ID_SEPARATOR,
             $parts_head
         );
     };
@@ -11,14 +11,13 @@ macro_rules! concat_parts {
         // `stringify!` will convert the expression *as it is* into a string.
         format!(
             "{}{}{}",
-            ID_SEPARATOR,
+            $crate::models::service::transactions::ID_SEPARATOR,
             $parts_head,
             concat_parts!($($parts_tail),+)
         );
     };
 }
 
-#[macro_export]
 macro_rules! create_id {
     ($tx_type:expr, $($parts:expr),+) => {
         // `stringify!` will convert the expression *as it is* into a string.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ extern crate rocket_contrib;
 
 extern crate dotenv;
 
+#[macro_use]
+pub mod macros;
+
 mod config;
 mod routes;
 mod services;

--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -88,3 +88,15 @@ pub struct Confirmation {
     pub confirmation_type: String,
     pub signature: Option<String>,
 }
+
+#[derive(Deserialize, Debug, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct CreationTransaction {
+    pub created: DateTime<Utc>,
+    pub creator: String,
+    pub transaction_hash: String,
+    pub factory_address: Option<String>,
+    pub master_copy: Option<String>,
+    pub setup_data: Option<String>,
+    pub data_decoded: Option<DataDecoded>,
+}

--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -97,6 +97,6 @@ pub struct CreationTransaction {
     pub transaction_hash: String,
     pub factory_address: Option<String>,
     pub master_copy: Option<String>,
-    // pub setup_data: Option<String>,
+    pub setup_data: Option<String>,
     // pub data_decoded: Option<DataDecoded>,
 }

--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -97,6 +97,6 @@ pub struct CreationTransaction {
     pub transaction_hash: String,
     pub factory_address: Option<String>,
     pub master_copy: Option<String>,
-    pub setup_data: Option<String>,
-    pub data_decoded: Option<DataDecoded>,
+    // pub setup_data: Option<String>,
+    // pub data_decoded: Option<DataDecoded>,
 }

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -2,7 +2,7 @@ extern crate chrono;
 
 pub mod details;
 pub mod summary;
-mod test;
+mod tests;
 
 use super::get_transfer_direction;
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -1,7 +1,5 @@
 extern crate chrono;
 
-#[macro_use]
-pub mod macros;
 pub mod details;
 pub mod summary;
 mod test;

--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -1,13 +1,11 @@
 extern crate chrono;
 
-use crate::models::backend::transactions::Transaction;
+use crate::models::backend::transactions::{Transaction, CreationTransaction};
 use crate::models::backend::transactions::{
     EthereumTransaction, ModuleTransaction, MultisigTransaction,
 };
 use crate::models::service::transactions::summary::{ExecutionInfo, TransactionSummary};
-use crate::models::service::transactions::{
-    TransactionStatus, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX, ID_PREFIX_MULTISIG_TX,
-};
+use crate::models::service::transactions::{TransactionStatus, ID_PREFIX_CREATION_TX, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX, ID_PREFIX_MULTISIG_TX, Creation, TransactionInfo};
 use crate::providers::info::InfoProvider;
 use crate::utils::hex_hash;
 use anyhow::{Error, Result};
@@ -97,5 +95,24 @@ impl ModuleTransaction {
             execution_info: None,
             tx_info: self.to_transaction_info(),
         }]
+    }
+}
+
+impl CreationTransaction {
+    pub fn to_creation(&self, safe_address: &String) -> TransactionSummary {
+        TransactionSummary {
+            id: create_id!(ID_PREFIX_CREATION_TX, safe_address),
+            timestamp: self.created.timestamp_millis(),
+            tx_status: TransactionStatus::Success,
+            tx_info: TransactionInfo::Creation(
+                Creation {
+                    creator: self.creator.clone(),
+                    transaction_hash: self.transaction_hash.clone(),
+                    master_copy: self.master_copy.clone(),
+                    factory: self.factory_address.clone(),
+                }
+            ),
+            execution_info: None,
+        }
     }
 }

--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -99,7 +99,7 @@ impl ModuleTransaction {
 }
 
 impl CreationTransaction {
-    pub fn to_creation(&self, safe_address: &String) -> TransactionSummary {
+    pub fn to_transaction_summary(&self, safe_address: &String) -> TransactionSummary {
         TransactionSummary {
             id: create_id!(ID_PREFIX_CREATION_TX, safe_address),
             timestamp: self.created.timestamp_millis(),

--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -7,7 +7,6 @@ use crate::models::backend::transactions::{
 use crate::models::service::transactions::summary::{ExecutionInfo, TransactionSummary};
 use crate::models::service::transactions::{
     TransactionStatus, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX, ID_PREFIX_MULTISIG_TX,
-    ID_SEPARATOR,
 };
 use crate::providers::info::InfoProvider;
 use crate::utils::hex_hash;

--- a/src/models/converters/transactions/tests/mod.rs
+++ b/src/models/converters/transactions/tests/mod.rs
@@ -1,0 +1,1 @@
+mod summary;

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod summary {
-    use crate::models::backend::transactions::{Transaction as TransactionDto, ModuleTransaction, EthereumTransaction};
+    use crate::models::backend::transactions::{Transaction as TransactionDto, ModuleTransaction, EthereumTransaction, CreationTransaction};
     use crate::providers::info::*;
     use chrono::Utc;
     use crate::models::commons::Operation;
-    use crate::models::service::transactions::{TransactionStatus, TransactionInfo, Custom, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX, ID_PREFIX_MULTISIG_TX, ID_SEPARATOR, Transfer, TransferDirection, TransferInfo, EtherTransfer};
+    use crate::models::service::transactions::{TransactionStatus, TransactionInfo, Custom, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_CREATION_TX, ID_PREFIX_MODULE_TX, Transfer, TransferDirection, TransferInfo, EtherTransfer, Creation};
     use crate::models::service::transactions::summary::TransactionSummary;
     use crate::utils::hex_hash;
     use crate::models::backend::transfers::{EtherTransfer as EtherTransferDto, Transfer as TransferDto};
@@ -156,5 +156,40 @@ mod summary {
                 execution_info: None,
             });
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn creation_transaction_to_summary() {
+        let created_date = Utc::now();
+        let safe_address = String::from("0x38497");
+        let creator = String::from("0x123");
+        let transaction_hash = String::from("0x2232");
+        let factory_address = String::from("0x123");
+        let master_copy = String::from("0x987");
+        let creation_tx = CreationTransaction {
+            created: created_date,
+            creator: creator.clone(),
+            transaction_hash: transaction_hash.clone(),
+            factory_address: Some(factory_address.clone()),
+            master_copy: Some(master_copy.clone()),
+        };
+        let expected = TransactionSummary {
+            id: create_id!(ID_PREFIX_CREATION_TX, safe_address),
+            timestamp: created_date.timestamp_millis(),
+            tx_status: TransactionStatus::Success,
+            tx_info: TransactionInfo::Creation(
+                Creation {
+                    creator: creator,
+                    transaction_hash: transaction_hash,
+                    master_copy: Some(master_copy),
+                    factory: Some(factory_address),
+                }
+            ),
+            execution_info: None,
+        };
+
+        let actual = creation_tx.to_transaction_summary(&safe_address);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -172,6 +172,7 @@ mod summary {
             transaction_hash: transaction_hash.clone(),
             factory_address: Some(factory_address.clone()),
             master_copy: Some(master_copy.clone()),
+            setup_data: None,
         };
         let expected = TransactionSummary {
             id: create_id!(ID_PREFIX_CREATION_TX, safe_address),

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod test {
+mod summary {
     use crate::models::backend::transactions::{Transaction as TransactionDto, ModuleTransaction, EthereumTransaction};
     use crate::providers::info::*;
     use chrono::Utc;

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -8,6 +8,7 @@ pub const ID_SEPARATOR: &str = "_";
 pub const ID_PREFIX_MULTISIG_TX: &str = "multisig";
 pub const ID_PREFIX_MODULE_TX: &str = "module";
 pub const ID_PREFIX_ETHEREUM_TX: &str = "ethereum";
+pub const ID_PREFIX_CREATION_TX: &str = "creation";
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -25,6 +26,7 @@ pub enum TransactionInfo {
     Transfer(Transfer),
     SettingsChange(SettingsChange),
     Custom(Custom),
+    Creation(Creation),
     Unknown,
 }
 
@@ -92,4 +94,13 @@ pub struct Custom {
     pub to: String,
     pub data_size: String,
     pub value: String,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Creation {
+    pub creator: String,
+    pub transaction_hash: String,
+    pub master_copy: Option<String>,
+    pub factory: Option<String>,
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod about;
 pub mod hooks;
 pub mod transactions_details;
 pub mod transactions_list;
+mod tests;

--- a/src/services/tests/mod.rs
+++ b/src/services/tests/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod transaction_list;

--- a/src/services/tests/transaction_list.rs
+++ b/src/services/tests/transaction_list.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod transaction_list {
     #[test]
-    fn create_transaction_map_creation() {
-    }
+    fn fetch_creation_at_list_end() {}
 }

--- a/src/services/tests/transaction_list.rs
+++ b/src/services/tests/transaction_list.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod transaction_list {
+    #[test]
+    fn create_transaction_map_creation() {
+    }
+}

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -110,7 +110,7 @@ pub fn get_transactions_details(
         ),
         ID_PREFIX_ETHEREUM_TX => get_ethereum_transaction_details(
             context,
-            id_parts.get(1).ok_or(anyhow::anyhow!("No safe adress"))?,
+            id_parts.get(1).ok_or(anyhow::anyhow!("No safe address"))?,
             id_parts
                 .get(2)
                 .ok_or(anyhow::anyhow!("No module tx block"))?
@@ -121,7 +121,7 @@ pub fn get_transactions_details(
         ),
         ID_PREFIX_MODULE_TX => get_module_transaction_details(
             context,
-            id_parts.get(1).ok_or(anyhow::anyhow!("No safe adress"))?,
+            id_parts.get(1).ok_or(anyhow::anyhow!("No safe address"))?,
             id_parts
                 .get(2)
                 .ok_or(anyhow::anyhow!("No module tx block"))?

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -2,7 +2,6 @@ extern crate reqwest;
 
 use crate::config::{base_transaction_service_url, request_cache_duration};
 use crate::models::backend::transactions::{Transaction, CreationTransaction};
-use crate::models::service::transactions::{ID_PREFIX_CREATION_TX, TransactionStatus, TransactionInfo, Creation};
 use crate::models::service::transactions::summary::TransactionSummary;
 use crate::models::commons::Page;
 use crate::utils::context::Context;
@@ -49,7 +48,7 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, next: &Opt
 
 fn get_creation_transaction_summary(
     context: &Context,
-    safe: &str,
+    safe: &String,
 ) -> Result<TransactionSummary> {
     let url = format!(
         "{}/safes/{}/creation",
@@ -62,19 +61,6 @@ fn get_creation_transaction_summary(
         .request_cached(&context.client(), &url, request_cache_duration())?;
 
     let creation_transaction_dto: CreationTransaction = serde_json::from_str(&body)?;
-    let transaction_summary = TransactionSummary {
-        id: create_id!(ID_PREFIX_CREATION_TX, safe),
-        timestamp: creation_transaction_dto.created.timestamp_millis(),
-        tx_status: TransactionStatus::Success,
-        tx_info: TransactionInfo::Creation(
-            Creation {
-                creator: creation_transaction_dto.creator,
-                transaction_hash: creation_transaction_dto.transaction_hash,
-                master_copy: creation_transaction_dto.master_copy,
-                factory: creation_transaction_dto.factory_address,
-            }
-        ),
-        execution_info: None,
-    };
+    let transaction_summary = creation_transaction_dto.to_creation(safe);
     Ok(transaction_summary)
 }

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -52,7 +52,7 @@ fn get_creation_transaction_summary(
     safe: &String,
 ) -> Result<TransactionSummary> {
     let url = format!(
-        "{}/safes/{}/creation",
+        "{}/safes/{}/creation/",
         base_transaction_service_url(),
         safe
     );

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -1,7 +1,8 @@
 extern crate reqwest;
 
 use crate::config::{base_transaction_service_url, request_cache_duration};
-use crate::models::backend::transactions::Transaction;
+use crate::models::backend::transactions::{Transaction, CreationTransaction};
+use crate::models::service::transactions::{ID_PREFIX_CREATION_TX, TransactionStatus, TransactionInfo, Creation};
 use crate::models::service::transactions::summary::TransactionSummary;
 use crate::models::commons::Page;
 use crate::utils::context::Context;
@@ -23,9 +24,13 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, next: &Opt
     debug!("next: {:#?}", next);
     debug!("{:#?}", body);
     let backend_transactions: Page<Transaction> = serde_json::from_str(&body)?;
-    let service_transactions: Vec<TransactionSummary> = backend_transactions.results.into_iter()
+    let mut service_transactions: Vec<TransactionSummary> = backend_transactions.results.into_iter()
         .flat_map(|transaction| transaction.to_transaction_summary(&mut info_provider, safe_address).unwrap_or(vec!()))
         .collect();
+    if backend_transactions.next.is_none() {
+        let creation_transaction = get_creation_transaction_summary(context, safe_address)?;
+        service_transactions.push(creation_transaction);
+    }
 
     Ok(Page {
         next: backend_transactions.next.as_ref()
@@ -40,4 +45,36 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, next: &Opt
             ),
         results: service_transactions,
     })
+}
+
+fn get_creation_transaction_summary(
+    context: &Context,
+    safe: &str,
+) -> Result<TransactionSummary> {
+    let url = format!(
+        "{}/safes/{}/creation",
+        base_transaction_service_url(),
+        safe
+    );
+    debug!("{}", &url);
+    let body = context
+        .cache()
+        .request_cached(&context.client(), &url, request_cache_duration())?;
+
+    let creation_transaction_dto: CreationTransaction = serde_json::from_str(&body)?;
+    let transaction_summary = TransactionSummary {
+        id: create_id!(ID_PREFIX_CREATION_TX, safe),
+        timestamp: creation_transaction_dto.created.timestamp_millis(),
+        tx_status: TransactionStatus::Success,
+        tx_info: TransactionInfo::Creation(
+            Creation {
+                creator: creation_transaction_dto.creator,
+                transaction_hash: creation_transaction_dto.transaction_hash,
+                master_copy: creation_transaction_dto.master_copy,
+                factory: creation_transaction_dto.factory_address,
+            }
+        ),
+        execution_info: None,
+    };
+    Ok(transaction_summary)
 }

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -27,8 +27,9 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, next: &Opt
         .flat_map(|transaction| transaction.to_transaction_summary(&mut info_provider, safe_address).unwrap_or(vec!()))
         .collect();
     if backend_transactions.next.is_none() {
-        let creation_transaction = get_creation_transaction_summary(context, safe_address)?;
-        service_transactions.push(creation_transaction);
+        if let Ok(creation_transaction) = get_creation_transaction_summary(context, safe_address) {
+            service_transactions.push(creation_transaction);
+        }
     }
 
     Ok(Page {

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -61,6 +61,6 @@ fn get_creation_transaction_summary(
         .request_cached(&context.client(), &url, request_cache_duration())?;
 
     let creation_transaction_dto: CreationTransaction = serde_json::from_str(&body)?;
-    let transaction_summary = creation_transaction_dto.to_creation(safe);
+    let transaction_summary = creation_transaction_dto.to_transaction_summary(safe);
     Ok(transaction_summary)
 }


### PR DESCRIPTION
Closes #56 

Changes:
- Added `CreationTransaction` for backend deserialisable types
- Added `Creation` concretization of `TransactionInfo` for `TransactionSummary`
- Cached results
- Improved test structure and added test for mapping
- Moved macros to root of the crate because of visibility issues in other modules