### PR TITLE
Closes #74 Safe TX hash usable for TX Details endpoint

### DIFF
--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -130,6 +130,7 @@ pub fn get_transactions_details(
                 .get(3)
                 .ok_or(anyhow::anyhow!("No module tx details hash"))?,
         ),
-        &_ => get_multisig_transaction_details(context, tx_type),
+        &_ => get_multisig_transaction_details(context, tx_type)
+            .map_err(|_| anyhow::anyhow!("Invalid details type or Id")),
     }
 }

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -130,6 +130,6 @@ pub fn get_transactions_details(
                 .get(3)
                 .ok_or(anyhow::anyhow!("No module tx details hash"))?,
         ),
-        &_ => Err(anyhow::anyhow!("Invalid details type")),
+        &_ => get_multisig_transaction_details(context, tx_type),
     }
 }


### PR DESCRIPTION
Closes #74 

- Else branch for resolving ID uses whatever is passed in the path as `SafeTxHash`

Not very elegant...