### PR TITLE
Closes #96 use TX Hash instead of block number for filtering TX details results

### DIFF
--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -67,7 +67,7 @@ impl EthereumTransaction {
                     id: create_id!(
                         ID_PREFIX_ETHEREUM_TX,
                         safe,
-                        self.block_number,
+                        self.tx_hash,
                         hex_hash(transfer)
                     ),
                     timestamp: self.execution_date.timestamp_millis(),
@@ -87,7 +87,7 @@ impl ModuleTransaction {
             id: create_id!(
                 ID_PREFIX_MODULE_TX,
                 self.safe,
-                self.block_number,
+                self.transaction_hash,
                 hex_hash(self)
             ),
             timestamp: self.execution_date.timestamp_millis(),

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -55,7 +55,7 @@ fn module_tx_to_summary_transaction() {
             id: create_id!(
                 ID_PREFIX_MODULE_TX,
                 module_tx.safe,
-                module_tx.block_number,
+                module_tx.transaction_hash,
                 hex_hash(&module_tx)
             ),
             timestamp: expected_date_in_millis,
@@ -131,7 +131,7 @@ fn ethereum_tx_to_summary_transaction_with_transfers() {
             id: create_id!(
                     ID_PREFIX_ETHEREUM_TX,
                     safe_address,
-                    ethereum_tx.block_number,
+                    ethereum_tx.tx_hash,
                     hex_hash(&ethereum_tx.transfers.as_ref().unwrap().get(0).unwrap())
                 ),
             timestamp: timestamp_millis,
@@ -150,7 +150,7 @@ fn ethereum_tx_to_summary_transaction_with_transfers() {
             id: create_id!(
                     ID_PREFIX_ETHEREUM_TX,
                     safe_address,
-                    ethereum_tx.block_number,
+                    ethereum_tx.tx_hash,
                     hex_hash(&ethereum_tx.transfers.as_ref().unwrap().get(1).unwrap())
                 ),
             timestamp: timestamp_millis,

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -37,15 +37,15 @@ fn get_multisig_transaction_details(
 fn get_ethereum_transaction_details(
     context: &Context,
     safe: &str,
-    block_number: u64,
+    tx_hash: &str,
     detail_hash: &str,
 ) -> Result<TransactionDetails> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
-        "{}/safes/{}/transfers/?block_number={}&limit=1000",
+        "{}/safes/{}/transfers/?transaction_hash={}&limit=1000",
         base_transaction_service_url(),
         safe,
-        block_number
+        tx_hash
     );
     debug!("url: {}", url);
     let body = context
@@ -70,14 +70,14 @@ fn get_ethereum_transaction_details(
 fn get_module_transaction_details(
     context: &Context,
     safe: &str,
-    block_number: u64,
+    tx_hash: &str,
     detail_hash: &str,
 ) -> Result<TransactionDetails> {
     let url = format!(
-        "{}/safes/{}/module-transactions/?block_number={}&limit=1000",
+        "{}/safes/{}/module-transactions/?transaction_hash={}&limit=1000",
         base_transaction_service_url(),
         safe,
-        block_number
+        tx_hash
     );
     debug!("url: {}", url);
     let body = context
@@ -113,8 +113,7 @@ pub fn get_transactions_details(
             id_parts.get(1).ok_or(anyhow::anyhow!("No safe address"))?,
             id_parts
                 .get(2)
-                .ok_or(anyhow::anyhow!("No module tx block"))?
-                .parse()?,
+                .ok_or(anyhow::anyhow!("No module tx hash"))?,
             id_parts
                 .get(3)
                 .ok_or(anyhow::anyhow!("No module tx details hash"))?,
@@ -124,8 +123,7 @@ pub fn get_transactions_details(
             id_parts.get(1).ok_or(anyhow::anyhow!("No safe address"))?,
             id_parts
                 .get(2)
-                .ok_or(anyhow::anyhow!("No module tx block"))?
-                .parse()?,
+                .ok_or(anyhow::anyhow!("No module tx hash"))?,
             id_parts
                 .get(3)
                 .ok_or(anyhow::anyhow!("No module tx details hash"))?,


### PR DESCRIPTION
Closes #96 

- Replaced `block_number` for `transaction_hash` for filtering TX details results
- Fixed tests accordingly.