### PR TITLE
Closes #90: Cache in-memory if no token info could be found

### DIFF
--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -57,9 +57,12 @@ impl ServiceCache {
         let data: String = match self.fetch(&url) {
             Some(cached) => cached,
             None => {
-                let response = client.get(url).send()?.text()?;
-                self.create(&url, &response, timeout);
-                response
+                let response = client.get(url).send()?;
+                // Don't cache if it is a Server error
+                 if response.status().is_server_error() { anyhow::bail!("Got server error for {}", url); };
+                let raw_data = response.text()?;
+                self.create(&url, &raw_data, timeout);
+                raw_data
             }
         };
         Ok(data)


### PR DESCRIPTION
Closes #90

- We already store in redis if the response errored
- Added this to in-memory cache with an Option

We should improve how `request_cached` works:
- Only cache on success (or add a flag to specify this)
- Return reqwest error to caller so that they can react to it if necessary
- This could be partially handled in https://github.com/gnosis/safe-client-gateway/issues/54 and if we see more changes necessary we create a follow up issue