### PR TITLE
Closes #107: Rename params

### DIFF
--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -108,7 +108,7 @@ impl CreationTransaction {
                 Creation {
                     creator: self.creator.clone(),
                     transaction_hash: self.transaction_hash.clone(),
-                    master_copy: self.master_copy.clone(),
+                    implementation: self.master_copy.clone(),
                     factory: self.factory_address.clone(),
                 }
             ),

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -194,7 +194,7 @@ fn creation_transaction_to_summary() {
             Creation {
                 creator: creator,
                 transaction_hash: transaction_hash,
-                master_copy: Some(master_copy),
+                implementation: Some(master_copy),
                 factory: Some(factory_address),
             }
         ),

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -101,6 +101,6 @@ pub struct Custom {
 pub struct Creation {
     pub creator: String,
     pub transaction_hash: String,
-    pub master_copy: Option<String>,
+    pub implementation: Option<String>,
     pub factory: Option<String>,
 }

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -5,10 +5,10 @@ use crate::services::transactions_list;
 use rocket::response::content;
 use anyhow::Result;
 
-#[get("/v1/safes/<safe_address>/transactions?<next>")]
-pub fn all(context: Context, safe_address: String, next: Option<String>) -> Result<content::Json<String>> {
+#[get("/v1/safes/<safe_address>/transactions?<page_url>")]
+pub fn all(context: Context, safe_address: String, page_url: Option<String>) -> Result<content::Json<String>> {
     context.cache().cache_resp(&context.uri(), request_cache_duration(), || {
-        transactions_list::get_all_transactions(&context, &safe_address, &next)
+        transactions_list::get_all_transactions(&context, &safe_address, &page_url)
     })
 }
 

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -10,17 +10,17 @@ use crate::providers::info::DefaultInfoProvider;
 use anyhow::Result;
 use log::debug;
 
-pub fn get_all_transactions(context: &Context, safe_address: &String, next: &Option<String>) -> Result<Page<TransactionSummary>> {
+pub fn get_all_transactions(context: &Context, safe_address: &String, page_url: &Option<String>) -> Result<Page<TransactionSummary>> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
         "{}/safes/{}/all-transactions/?{}",
         base_transaction_service_url(),
         safe_address,
-        next.as_ref().unwrap_or(&String::new())
+        page_url.as_ref().unwrap_or(&String::new())
     );
     let body = context.cache().request_cached(&context.client(), &url, request_cache_duration())?;
     debug!("request URL: {}", &url);
-    debug!("next: {:#?}", next);
+    debug!("page_url: {:#?}", page_url);
     debug!("{:#?}", body);
     let backend_transactions: Page<Transaction> = serde_json::from_str(&body)?;
     let mut service_transactions: Vec<TransactionSummary> = backend_transactions.results.into_iter()


### PR DESCRIPTION
Closes #107
- Rename `master_copy` in creation to `implementation` 
- Rename `next` in transcations endpoint to `page_url`