### PR TITLE
Closes #124 : Invalidate cache with safe tx hash if possible

### DIFF
--- a/src/routes/hooks.rs
+++ b/src/routes/hooks.rs
@@ -10,5 +10,5 @@ pub fn update(context: Context, token: String, update: Json<Payload>) -> Result<
     if token != webhook_token() {
         bail!("Invalid token");
     }
-    invalidate_caches(&context, &update.address)
+    invalidate_caches(&context, &update)
 }

--- a/src/services/hooks.rs
+++ b/src/services/hooks.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 pub fn invalidate_caches(context: &Context, payload: &Payload) -> Result<()> {
     let cache = context.cache();
     cache.invalidate_pattern(&format!("*{}*", &payload.address));
-    payload.details.map(|d| {
+    payload.details.as_ref().map(|d| {
         match d {
             PayloadDetails::NewConfirmation(data) => {
                 cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));

--- a/src/services/hooks.rs
+++ b/src/services/hooks.rs
@@ -1,7 +1,23 @@
 use crate::utils::context::Context;
+use crate::models::backend::webhooks::{Payload, PayloadDetails};
 use anyhow::Result;
 
-pub fn invalidate_caches(context: &Context, safe: &String) -> Result<()> {
-    context.cache().invalidate_pattern(&format!("*{}*", safe));
+pub fn invalidate_caches(context: &Context, payload: &Payload) -> Result<()> {
+    let cache = context.cache();
+    cache.invalidate_pattern(&format!("*{}*", &payload.address));
+    payload.details.map(|d| {
+        match d {
+            PayloadDetails::NewConfirmation(data) => {
+                cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            },
+            PayloadDetails::ExecutedMultisigTransaction(data) => {
+                cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            },
+            PayloadDetails::PendingMultisigTransaction(data) => {
+                cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            },
+            _ => {}
+        }
+    });
     Ok(())
 }


### PR DESCRIPTION
Closes #124 
- Invalidate cache with `safe_tx_hash` for new confirmations, for execution of multisig transactions and new pending multisig transactions

Created #125 for tests