### PR TITLE
Closes #54 Better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "thiserror",
 ]
 
 [[package]]
@@ -2085,6 +2086,26 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ derivative = "2.1.1"
 chrono = { version = "0.4", features = ["serde"] }
 
 anyhow = "1.0"
+thiserror = "1.0.20"
 
 mockall = "0.7.2"
 

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -2,17 +2,17 @@ use crate::config::{about_cache_duration};
 use crate::utils::context::Context;
 use crate::services::about;
 use rocket::response::content;
-use anyhow::Result;
 use crate::config::{base_transaction_service_url};
 use crate::utils::cache::CacheExt;
+use crate::utils::errors::ApiResult;
 
 #[get("/about")]
-pub fn info(context: Context) -> Result<content::Json<String>> {
+pub fn info(context: Context) -> ApiResult<content::Json<String>> {
     context.cache().cache_resp(&context.uri(), about_cache_duration(), about::get_about)
 }
 
 #[get("/about/backbone")]
-pub fn backbone(context: Context) -> Result<content::Json<String>> {
+pub fn backbone(context: Context) -> ApiResult<content::Json<String>> {
     let url = format!(
         "{}/about",
         base_transaction_service_url()

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -4,17 +4,17 @@ use crate::services::transactions_details;
 use crate::services::transactions_list;
 use crate::utils::cache::CacheExt;
 use rocket::response::content;
-use anyhow::Result;
+use crate::utils::errors::ApiResult;
 
 #[get("/v1/safes/<safe_address>/transactions?<page_url>")]
-pub fn all(context: Context, safe_address: String, page_url: Option<String>) -> Result<content::Json<String>> {
+pub fn all(context: Context, safe_address: String, page_url: Option<String>) -> ApiResult<content::Json<String>> {
     context.cache().cache_resp(&context.uri(), request_cache_duration(), || {
         transactions_list::get_all_transactions(&context, &safe_address, &page_url)
     })
 }
 
 #[get("/v1/transactions/<details_id>")]
-pub fn details(context: Context, details_id: String) -> Result<content::Json<String>> {
+pub fn details(context: Context, details_id: String) -> ApiResult<content::Json<String>> {
     context.cache().cache_resp(&context.uri(), request_cache_duration(), || {
         transactions_details::get_transactions_details(&context, &details_id)
     })

--- a/src/services/about.rs
+++ b/src/services/about.rs
@@ -1,10 +1,10 @@
 extern crate reqwest;
 
 use crate::config::{base_transaction_service_url, version, build_number};
-use anyhow::Result;
 use crate::models::service::about::About;
+use crate::utils::errors::ApiResult;
 
-pub fn get_about() -> Result<About> {
+pub fn get_about() -> ApiResult<About> {
     Ok(About {
         transaction_service_base_url: base_transaction_service_url(),
         name: env!("CARGO_PKG_NAME").to_string(),

--- a/src/services/tests/invalidate_caches.rs
+++ b/src/services/tests/invalidate_caches.rs
@@ -23,7 +23,7 @@ fn invalidate_with_empty_payload() {
         .times(0);
     mock_cache
         .expect_invalidate_pattern()
-        .with(eq(String::from("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*")))
+        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .return_const(())
         .times(1);
 
@@ -56,13 +56,13 @@ fn invalidate_new_confirmation_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*")))
+        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*")))
+        .with(eq("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*"))
         .in_sequence(&mut sequence);
 
     invalidate_caches(&mock_cache, &payload).unwrap();
@@ -94,13 +94,13 @@ fn invalidate_executed_multisig_transaction_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*")))
+        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*")))
+        .with(eq("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*"))
         .in_sequence(&mut sequence);
 
     invalidate_caches(&mock_cache, &payload).unwrap();
@@ -131,13 +131,13 @@ fn invalidate_pending_multisig_transaction_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*")))
+        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq(String::from("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*")))
+        .with(eq("*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*"))
         .in_sequence(&mut sequence);
 
     invalidate_caches(&mut mock_cache, &payload).unwrap();

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -12,13 +12,13 @@ use crate::providers::info::DefaultInfoProvider;
 use crate::utils::context::Context;
 use crate::utils::hex_hash;
 use crate::utils::cache::CacheExt;
-use anyhow::Result;
 use log::debug;
+use crate::utils::errors::ApiResult;
 
 fn get_multisig_transaction_details(
     context: &Context,
     safe_tx_hash: &str,
-) -> Result<TransactionDetails> {
+) -> ApiResult<TransactionDetails> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
         "{}/transactions/{}",
@@ -40,7 +40,7 @@ fn get_ethereum_transaction_details(
     safe: &str,
     tx_hash: &str,
     detail_hash: &str,
-) -> Result<TransactionDetails> {
+) -> ApiResult<TransactionDetails> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
         "{}/safes/{}/transfers/?transaction_hash={}&limit=1000",
@@ -73,7 +73,7 @@ fn get_module_transaction_details(
     safe: &str,
     tx_hash: &str,
     detail_hash: &str,
-) -> Result<TransactionDetails> {
+) -> ApiResult<TransactionDetails> {
     let url = format!(
         "{}/safes/{}/module-transactions/?transaction_hash={}&limit=1000",
         base_transaction_service_url(),
@@ -98,7 +98,7 @@ fn get_module_transaction_details(
 pub fn get_transactions_details(
     context: &Context,
     details_id: &String,
-) -> Result<TransactionDetails> {
+) -> ApiResult<TransactionDetails> {
     let id_parts: Vec<&str> = details_id.split(ID_SEPARATOR).collect();
     let tx_type = id_parts.get(0).ok_or(anyhow::anyhow!("Invalid id"))?;
 
@@ -129,7 +129,6 @@ pub fn get_transactions_details(
                 .get(3)
                 .ok_or(anyhow::anyhow!("No module tx details hash"))?,
         ),
-        &_ => get_multisig_transaction_details(context, tx_type)
-            .map_err(|_| anyhow::anyhow!("Invalid details type or Id")),
+        &_ => get_multisig_transaction_details(context, tx_type),
     }
 }

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -51,7 +51,7 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, page_url: 
 fn get_creation_transaction_summary(
     context: &Context,
     safe: &String,
-) -> anyhow::Result<TransactionSummary> {
+) -> ApiResult<TransactionSummary> {
     let url = format!(
         "{}/safes/{}/creation/",
         base_transaction_service_url(),

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -8,10 +8,10 @@ use crate::utils::context::Context;
 use crate::utils::extract_query_string;
 use crate::utils::cache::CacheExt;
 use crate::providers::info::DefaultInfoProvider;
-use anyhow::Result;
 use log::debug;
+use crate::utils::errors::ApiResult;
 
-pub fn get_all_transactions(context: &Context, safe_address: &String, page_url: &Option<String>) -> Result<Page<TransactionSummary>> {
+pub fn get_all_transactions(context: &Context, safe_address: &String, page_url: &Option<String>) -> ApiResult<Page<TransactionSummary>> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
         "{}/safes/{}/all-transactions/?{}",
@@ -51,7 +51,7 @@ pub fn get_all_transactions(context: &Context, safe_address: &String, page_url: 
 fn get_creation_transaction_summary(
     context: &Context,
     safe: &String,
-) -> Result<TransactionSummary> {
+) -> anyhow::Result<TransactionSummary> {
     let url = format!(
         "{}/safes/{}/creation/",
         base_transaction_service_url(),

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -3,7 +3,7 @@ use rocket_contrib::databases::redis::{self, pipe, Commands, Iter, PipelineComma
 use serde::ser::Serialize;
 use serde_json;
 use mockall::automock;
-use crate::utils::errors::{ApiResult, ApiError, ApiErrorMessage};
+use crate::utils::errors::{ApiResult, ApiError};
 
 #[database("service_cache")]
 pub struct ServiceCache(redis::Connection);
@@ -77,10 +77,7 @@ pub trait CacheExt: Cache {
                 let status_code = response.status().as_u16();
 
                 if response.status().is_server_error() {
-                    return Err(ApiError {
-                        status: status_code,
-                        message: ApiErrorMessage::SingleLine(String::from("Got server error for {}")),
-                    });
+                    return Err(ApiError::from_backend_error(42, format!("Got server error for {}", response.text()?).as_str()));
                 }
                 let is_client_error = response.status().is_client_error();
                 let raw_data = response.text()?;

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -79,7 +79,6 @@ pub trait CacheExt: Cache {
             None => {
                 let response = client.get(url).send()?;
                 if response.status().is_server_error() {
-                    // This should panic or be refactored to return an error
                     return Err(anyhow::anyhow!("Got server error for {}", url).into());
                 }
                 let status_code = response.status().as_u16();

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -113,10 +113,10 @@ impl CachedWithCode {
     }
 
     pub(super) fn to_result(&self) -> Result<String, ApiError> {
-        if !self.is_error() {
-            Ok(String::from(&self.data))
-        } else {
+        if self.is_error() {
             Err(ApiError::from_backend_error(self.code, &self.data))
+        } else {
+            Ok(String::from(&self.data))
         }
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -65,12 +65,7 @@ pub trait CacheExt: Cache {
     ) -> ApiResult<String> {
         match self.fetch(&url) {
             Some(cached) => {
-                let cached_with_code = CachedWithCode::split(&cached);
-                return if !cached_with_code.is_error() {
-                    Ok(String::from(cached_with_code.data))
-                } else {
-                    Err(ApiError::from_backend_error(cached_with_code.code, &cached_with_code.data))
-                };
+                CachedWithCode::split(&cached).to_result()
             }
             None => {
                 let response = client.get(url).send()?;
@@ -115,6 +110,14 @@ impl CachedWithCode {
 
     pub(super) fn is_error(&self) -> bool {
         200 > self.code || self.code >= 400
+    }
+
+    pub(super) fn to_result(&self) -> Result<String, ApiError> {
+        if !self.is_error() {
+            Ok(String::from(&self.data))
+        } else {
+            Err(ApiError::from_backend_error(self.code, &self.data))
+        }
     }
 }
 

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -38,7 +38,7 @@ impl From<anyhow::Error> for ApiError {
     fn from(err: anyhow::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("{:?}", err)),
+            message: Some(format!("ANYHOW: {:?}", err)),
         }
     }
 }
@@ -47,7 +47,7 @@ impl From<reqwest::Error> for ApiError {
     fn from(err: reqwest::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("{:?}", err)),
+            message: Some(format!("REQWEST: {:?}", err)),
         }
     }
 }
@@ -56,7 +56,7 @@ impl From<serde_json::error::Error> for ApiError {
     fn from(err: serde_json::error::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("{:?}", err)),
+            message: Some(format!("SERDE: {:?}", err)),
         }
     }
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -42,14 +42,11 @@ impl ApiError {
     }
 
     fn new_internal(message: String) -> Self {
-        Self {
-            status: 500,
-            details: ErrorDetails {
-                code: 1337,
-                message: Some(message),
-                arguments: None,
-            },
-        }
+        Self::new(500, ErrorDetails {
+            code: 1337,
+            message: Some(message),
+            arguments: None,
+        })
     }
 }
 

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 
 pub type ApiResult<T, E = ApiError> = Result<T, E>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub struct ApiError {
     pub status: u16,
     pub details: ErrorDetails,

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -25,7 +25,7 @@ pub struct ErrorDetails {
 }
 
 impl ApiError {
-    pub fn from_backend_error(status_code: u16, raw_error: &str) -> ApiError {
+    pub fn from_backend_error(status_code: u16, raw_error: &str) -> Self {
         let error_details = match serde_json::from_str::<ErrorDetails>(&raw_error) {
             Ok(backend_error) => backend_error,
             Err(_) => ErrorDetails {
@@ -37,8 +37,19 @@ impl ApiError {
         ApiError::new(status_code, error_details)
     }
 
-    fn new(status_code: u16, message: ErrorDetails) -> ApiError {
+    fn new(status_code: u16, message: ErrorDetails) -> Self {
         ApiError { status: status_code, details: message }
+    }
+
+    fn new_internal(message: String) -> Self {
+        Self {
+            status: 500,
+            details: ErrorDetails {
+                code: 1337,
+                message: Some(message),
+                arguments: None,
+            },
+        }
     }
 }
 
@@ -70,39 +81,18 @@ impl<'r> Responder<'r> for ApiError {
 
 impl From<anyhow::Error> for ApiError {
     fn from(err: anyhow::Error) -> Self {
-        Self {
-            status: 500,
-            details: ErrorDetails {
-                code: 1337,
-                message: Some(format!("{:?}", err)),
-                arguments: None,
-            },
-        }
+        Self::new_internal(format!("{:?}", err))
     }
 }
 
 impl From<reqwest::Error> for ApiError {
     fn from(err: reqwest::Error) -> Self {
-        Self {
-            status: 500,
-            details: ErrorDetails {
-                code: 1337,
-                message: Some(format!("{:?}", err)),
-                arguments: None,
-            },
-        }
+        Self::new_internal(format!("{:?}", err))
     }
 }
 
 impl From<serde_json::error::Error> for ApiError {
     fn from(err: serde_json::error::Error) -> Self {
-        Self {
-            status: 500,
-            details: ErrorDetails {
-                code: 1337,
-                message: Some(format!("{:?}", err)),
-                arguments: None,
-            },
-        }
+        Self::new_internal(format!("{:?}", err))
     }
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -31,6 +31,20 @@ pub struct BackendError {
     pub arguments: Option<Vec<String>>,
 }
 
+impl ApiError {
+     fn new(status_code: u16, message: ApiErrorMessage) -> ApiError {
+        ApiError { status: status_code, message }
+    }
+
+    pub fn from_backend_error(status_code: u16, raw_error: &str) -> ApiError{
+        if let Ok(backend_error) = serde_json::from_str::<BackendError>(&raw_error){
+            ApiError::new(status_code, ApiErrorMessage::BackendError(backend_error))
+        }else{
+            ApiError::new(1337, ApiErrorMessage::SingleLine(raw_error.to_owned()))
+        }
+    }
+}
+
 impl fmt::Display for ApiErrorMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -34,11 +34,11 @@ impl ApiError {
                 arguments: None,
             },
         };
-        ApiError::new(status_code, error_details)
+        Self::new(status_code, error_details)
     }
 
     fn new(status_code: u16, message: ErrorDetails) -> Self {
-        ApiError { status: status_code, details: message }
+        Self { status: status_code, details: message }
     }
 
     fn new_internal(message: String) -> Self {

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 
 pub type ApiResult<T, E = ApiError> = Result<T, E>;
 
-#[derive(Error, Debug, Serialize)]
+#[derive(Error, Debug)]
 pub struct ApiError {
     pub status: u16,
     pub details: ErrorDetails,

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -52,8 +52,8 @@ impl From<reqwest::Error> for ApiError {
     }
 }
 
-impl From<serde_json::Error> for ApiError {
-    fn from(err: serde_json::Error) -> Self {
+impl From<serde_json::error::Error> for ApiError {
+    fn from(err: serde_json::error::Error) -> Self {
         Self {
             status: 500,
             message: Some(format!("{:?}", err)),

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+use thiserror::Error;
+use rocket::request::Request;
+use rocket::response::{self, Response, Responder};
+use rocket::http::{ContentType, Status};
+use serde_json;
+use serde::Serialize;
+use std::io::Cursor;
+use log::debug;
+use anyhow::Result;
+
+pub type ApiResult<T, E = ApiError> = Result<T, E>;
+
+#[derive(Error, Debug, Serialize)]
+pub struct ApiError {
+    pub status: u16,
+    pub message: Option<String>,
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ApiError({}: {})", self.status, self.message.as_ref().unwrap_or(&"Unknown error".to_owned()))
+    }
+}
+
+impl<'r> Responder<'r> for ApiError {
+    fn respond_to(self, _: &Request) -> response::Result<'r> {
+        debug!("Handle ApiError");
+        Response::build()
+            .sized_body(Cursor::new(serde_json::to_string(&self).expect("Couldn't serialize error")))
+            .header(ContentType::JSON)
+            .status(Status::from_code(self.status).expect("Unknown status code"))
+            .ok()
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(err: anyhow::Error) -> Self {
+        Self {
+            status: 500,
+            message: Some(format!("{:?}", err)),
+        }
+    }
+}
+
+impl From<reqwest::Error> for ApiError {
+    fn from(err: reqwest::Error) -> Self {
+        Self {
+            status: 500,
+            message: Some(format!("{:?}", err)),
+        }
+    }
+}
+
+impl From<serde_json::Error> for ApiError {
+    fn from(err: serde_json::Error) -> Self {
+        Self {
+            status: 500,
+            message: Some(format!("{:?}", err)),
+        }
+    }
+}

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -38,7 +38,7 @@ impl From<anyhow::Error> for ApiError {
     fn from(err: anyhow::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("ANYHOW: {:?}", err)),
+            message: Some(format!("{:?}", err)),
         }
     }
 }
@@ -47,7 +47,7 @@ impl From<reqwest::Error> for ApiError {
     fn from(err: reqwest::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("REQWEST: {:?}", err)),
+            message: Some(format!("{:?}", err)),
         }
     }
 }
@@ -56,7 +56,7 @@ impl From<serde_json::error::Error> for ApiError {
     fn from(err: serde_json::error::Error) -> Self {
         Self {
             status: 500,
-            message: Some(format!("SERDE: {:?}", err)),
+            message: Some(format!("{:?}", err)),
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,10 @@ pub mod cors;
 pub mod context;
 pub mod cache;
 pub mod json;
+pub mod errors;
+
+#[cfg(test)]
+mod tests;
 
 //TODO think of a better impl, using enums as per Nick's suggestion
 pub const TRANSFER_METHOD: &str = "transfer";

--- a/src/utils/tests/cache.rs
+++ b/src/utils/tests/cache.rs
@@ -1,4 +1,5 @@
 use crate::utils::cache::CachedWithCode;
+use crate::utils::errors::{ApiError, ErrorDetails};
 
 #[test]
 fn cache_with_code_split_success() {
@@ -28,7 +29,7 @@ fn cache_with_code_split_failure_not_enough_parts() {
 
 #[test]
 fn cache_with_code_split_multiple_separators() {
-    let expected = CachedWithCode{ code: 404, data: String::from("foo;bar") };
+    let expected = CachedWithCode { code: 404, data: String::from("foo;bar") };
     let actual = CachedWithCode::split("404;foo;bar");
 
     assert_eq!(actual, expected);
@@ -36,7 +37,7 @@ fn cache_with_code_split_multiple_separators() {
 
 #[test]
 fn cache_with_code_split_data_is_only_separators() {
-    let expected = CachedWithCode{ code: 404, data: String::from(";;;;;") };
+    let expected = CachedWithCode { code: 404, data: String::from(";;;;;") };
     let actual = CachedWithCode::split("404;;;;;;");
 
     assert_eq!(actual, expected);
@@ -52,14 +53,36 @@ fn cache_with_code_join() {
 
 #[test]
 fn cache_with_code_error_code() {
-    let cached_with_code = CachedWithCode{ code: 418, data: "teapot".to_string() };
+    let cached_with_code = CachedWithCode { code: 418, data: "teapot".to_string() };
 
     assert!(cached_with_code.is_error())
 }
 
 #[test]
 fn cache_with_code_success_code() {
-    let cached_with_code = CachedWithCode{ code: 200, data: "not a teapot".to_string() };
+    let cached_with_code = CachedWithCode { code: 200, data: "not a teapot".to_string() };
 
     assert!(!cached_with_code.is_error())
+}
+
+#[test]
+fn cache_with_code_unwrap_ok() {
+    let cached_with_code = CachedWithCode { code: 200, data: "not a teapot".to_string() };
+
+    assert_eq!(cached_with_code.to_result().unwrap(), "not a teapot");
+}
+
+#[test]
+fn cache_with_code_unwrap_err() {
+    let cached_with_code = CachedWithCode { code: 418, data: "teapot".to_string() };
+    let expected = ApiError {
+        status: 418,
+        details: ErrorDetails {
+            code: 42,
+            message: Some(String::from("teapot")),
+            arguments: None,
+        },
+    };
+
+    assert_eq!(cached_with_code.to_result().expect_err(""), expected);
 }

--- a/src/utils/tests/cache.rs
+++ b/src/utils/tests/cache.rs
@@ -1,0 +1,49 @@
+use crate::utils::cache::CachedWithCode;
+
+#[test]
+fn cache_with_code_split_success() {
+    let input = "400;123";
+
+    let cached_with_code = CachedWithCode::split(input);
+    let expected = CachedWithCode {
+        code: 400,
+        data: String::from("123"),
+    };
+
+    assert_eq!(cached_with_code, expected);
+}
+
+#[test]
+#[should_panic]
+fn cache_with_code_split_failure_parse() {
+    CachedWithCode::split("400A;123");
+}
+
+
+#[test]
+#[should_panic]
+fn cache_with_code_split_failure_not_enough_parts() {
+    CachedWithCode::split("400MissingSeparatorForSomeReason");
+}
+
+#[test]
+fn cache_with_code_join() {
+    let actual = CachedWithCode::join(400, "data");
+    let expected = String::from("400;data");
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn cache_with_code_error_code() {
+    let cached_with_code = CachedWithCode{ code: 418, data: "teapot".to_string() };
+
+    assert!(cached_with_code.is_error())
+}
+
+#[test]
+fn cache_with_code_success_code() {
+    let cached_with_code = CachedWithCode{ code: 200, data: "not a teapot".to_string() };
+
+    assert!(!cached_with_code.is_error())
+}

--- a/src/utils/tests/cache.rs
+++ b/src/utils/tests/cache.rs
@@ -27,6 +27,22 @@ fn cache_with_code_split_failure_not_enough_parts() {
 }
 
 #[test]
+fn cache_with_code_split_multiple_separators() {
+    let expected = CachedWithCode{ code: 404, data: String::from("foo;bar") };
+    let actual = CachedWithCode::split("404;foo;bar");
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn cache_with_code_split_data_is_only_separators() {
+    let expected = CachedWithCode{ code: 404, data: String::from(";;;;;") };
+    let actual = CachedWithCode::split("404;;;;;;");
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn cache_with_code_join() {
     let actual = CachedWithCode::join(400, "data");
     let expected = String::from("400;data");

--- a/src/utils/tests/errors.rs
+++ b/src/utils/tests/errors.rs
@@ -8,18 +8,19 @@ fn api_error_responder_json() {
     let api_error = ApiError {
         status: 418,
         details: ErrorDetails {
-            code: 42,
+            code: 1337,
             message: Some("Not found".to_string()),
             arguments: None,
         },
     };
-    let expected_error_json = r#"{"status":418,"details":{"code":42,"message":"Not found"}}"#;
+    let expected_error_json = r#"{"code":1337,"message":"Not found"}"#;
+
     let rocket = rocket::ignite();
     let client = Client::new(rocket).expect("valid rocket instance");
-
     let local_request = client.get("/");
     let request = local_request.inner();
     let mut response = api_error.respond_to(&request).unwrap();
+
     let body_json = response.body().unwrap().into_string().unwrap();
 
     assert_eq!(response.status().code, 418);
@@ -30,7 +31,7 @@ fn api_error_responder_json() {
 fn api_error_from_anyhow_error() {
     let error = anyhow::anyhow!("Error message");
     let error_details = ErrorDetails {
-        code: 42,
+        code: 1337,
         message: Some("Error message".to_string()),
         arguments: None,
     };
@@ -86,10 +87,9 @@ fn api_error_unknown_error_json_structure() {
           "0x1230b3d59858296A31053C1b8562Ecf89A2f888b"
         ]
     }"#;
-    let json_error = serde_json::from_str::<ErrorDetails>(&expected_error_json).expect_err("New unknown structure");
     let expected_error = ErrorDetails {
-        code: 1337,
-        message: Some(format!("Serde serialization error: {}", json_error.to_string())),
+        code: 42,
+        message: Some(expected_error_json.to_owned()),
         arguments: None,
     };
 

--- a/src/utils/tests/errors.rs
+++ b/src/utils/tests/errors.rs
@@ -1,11 +1,11 @@
 use rocket::local::Client;
-use crate::utils::errors::ApiError;
+use crate::utils::errors::{ApiError, ApiErrorMessage};
 use rocket::response::Responder;
 use crate::models::backend::transactions::MultisigTransaction;
 
 #[test]
 fn api_error_responder_json() {
-    let api_error = ApiError { status: 418, message: Some(String::from("Not found")) };
+    let api_error = ApiError { status: 418, message: ApiErrorMessage::SingleLine(String::from("Not found")) };
     let rocket = rocket::ignite();
     let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -25,7 +25,7 @@ fn api_error_from_anyhow_error() {
     let actual = ApiError::from(error);
 
     assert_eq!(actual.status, 500);
-    assert_eq!(actual.message.unwrap(), "Error message");
+    assert_eq!(actual.message, ApiErrorMessage::SingleLine(String::from("Error message")));
 }
 
 #[test]
@@ -36,5 +36,5 @@ fn api_error_from_serde_error() {
     let actual = ApiError::from(error);
 
     assert_eq!(actual.status, 500);
-    assert_eq!(actual.message.unwrap(), error_message);
+    assert_eq!(actual.message, ApiErrorMessage::SingleLine(error_message));
 }

--- a/src/utils/tests/errors.rs
+++ b/src/utils/tests/errors.rs
@@ -5,7 +5,7 @@ use crate::models::backend::transactions::MultisigTransaction;
 
 #[test]
 fn api_error_responder_json() {
-    let api_error = ApiError { status: 404, message: Some(String::from("Not found")) };
+    let api_error = ApiError { status: 418, message: Some(String::from("Not found")) };
     let rocket = rocket::ignite();
     let client = Client::new(rocket).expect("valid rocket instance");
 
@@ -14,8 +14,8 @@ fn api_error_responder_json() {
     let mut response = api_error.respond_to(&request).unwrap();
     let body_json = response.body().unwrap().into_string().unwrap();
 
-    assert_eq!(response.status().code, 404);
-    assert_eq!(body_json, "{\"status\":404,\"message\":\"Not found\"}");
+    assert_eq!(response.status().code, 418);
+    assert_eq!(body_json, "{\"status\":418,\"message\":\"Not found\"}");
 }
 
 #[test]

--- a/src/utils/tests/errors.rs
+++ b/src/utils/tests/errors.rs
@@ -1,0 +1,25 @@
+use rocket::local::Client;
+use rocket::http::Status;
+use crate::utils::errors::{ApiError, ApiResult};
+
+#[get("/")]
+fn not_found() -> ApiResult<()> {
+    Err(ApiError {
+        status: 404,
+        message: Some("Not found".to_string()),
+    })
+}
+
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![not_found])
+}
+
+#[test]
+fn failure_route() {
+    let client = Client::new(rocket()).expect("valid rocket instance");
+    let mut response = client.get("/").dispatch();
+    assert_eq!(response.status(), Status::from_code(404).unwrap());
+    assert_eq!(response.body_string(), Some("{\"status\":404,\"message\":\"Not found\"}".into()));
+}
+
+

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,0 +1,1 @@
+mod errors;

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,1 +1,2 @@
 mod errors;
+mod cache;


### PR DESCRIPTION
Closes #54 
- Added `ApiResult` type alias with type wrappers for most common errors
- Tests 
- Added polymorphic `message` field
- Attempted deserialisation of the backend error
- client errors are cached