### PR TITLE
Closes #53 Fields for sign submission

### DIFF
--- a/src/models/converters/transactions/details.rs
+++ b/src/models/converters/transactions/details.rs
@@ -2,7 +2,7 @@ extern crate chrono;
 
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::models::commons::Operation;
-use crate::models::service::transactions::details::{DetailedExecutionInfo, ModuleExecutionDetails, MultisigConfirmation, MultisigExecutionDetails, TransactionData, TransactionDetails, SignatureInfo};
+use crate::models::service::transactions::details::{DetailedExecutionInfo, ModuleExecutionDetails, MultisigConfirmation, MultisigExecutionDetails, TransactionData, TransactionDetails};
 use crate::models::service::transactions::TransactionStatus;
 use crate::providers::info::{InfoProvider, SafeInfo, TokenInfo};
 use anyhow::Result;
@@ -13,7 +13,17 @@ impl MultisigTransaction {
         info_provider: &mut dyn InfoProvider,
     ) -> Result<TransactionDetails> {
         let safe_info = info_provider.safe_info(&self.safe.to_string())?;
-        let gas_token = self.gas_token.as_ref().map(|token_address| info_provider.token_info(&token_address).ok()).flatten();
+        let gas_token = if let Some(gas_token) = &self.gas_token {
+            if gas_token != "0x0000000000000000000000000000000000000000" {
+                info_provider.token_info(gas_token).ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        //self.gas_token.as_ref().map(|token_address| info_provider.token_info(&token_address).ok()).flatten();
         Ok(TransactionDetails {
             executed_at: self.execution_date.map(|data| data.timestamp_millis()),
             tx_status: self.map_status(&safe_info),
@@ -30,7 +40,7 @@ impl MultisigTransaction {
         })
     }
 
-    fn build_execution_details(&self, safe_info: SafeInfo, gas_token: Option<TokenInfo>) -> MultisigExecutionDetails {
+    fn build_execution_details(&self, safe_info: SafeInfo, gas_token_info: Option<TokenInfo>) -> MultisigExecutionDetails {
         MultisigExecutionDetails {
             submitted_at: self.submission_date.timestamp_millis(),
             nonce: self.nonce,
@@ -51,18 +61,12 @@ impl MultisigTransaction {
                     submitted_at: confirmation.submission_date.timestamp_millis(),
                 })
                 .collect(),
-            signature_info: Some(self.build_signature_info(gas_token)),
-        }
-    }
-
-    fn build_signature_info(&self, gas_token: Option<TokenInfo>) -> SignatureInfo {
-        SignatureInfo {
-            refund_receiver: self.refund_receiver.to_owned(),
+            refund_receiver: self.refund_receiver.as_ref().unwrap_or(&String::from("0x0000000000000000000000000000000000000000")).to_owned(),
+            gas_token: self.gas_token.as_ref().unwrap_or(&String::from("0x0000000000000000000000000000000000000000")).to_owned(),
             base_gas: self.base_gas,
             safe_tx_gas: self.safe_tx_gas,
-            gas_limit: self.gas_price.to_owned(),
-            gas_token: gas_token.as_ref().map(|it| it.address.to_owned()).unwrap_or(String::from("0x0000000000000000000000000000000000000000")),
-            gas_token_info: gas_token,
+            gas_price: self.gas_price.to_owned(),
+            gas_token_info: gas_token_info,
         }
     }
 }

--- a/src/models/converters/transactions/details.rs
+++ b/src/models/converters/transactions/details.rs
@@ -13,17 +13,8 @@ impl MultisigTransaction {
         info_provider: &mut dyn InfoProvider,
     ) -> Result<TransactionDetails> {
         let safe_info = info_provider.safe_info(&self.safe.to_string())?;
-        let gas_token = if let Some(gas_token) = &self.gas_token {
-            if gas_token != "0x0000000000000000000000000000000000000000" {
-                info_provider.token_info(gas_token).ok()
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        let gas_token = self.gas_token.as_ref().map(|it| info_provider.token_info(it).ok()).flatten();
 
-        //self.gas_token.as_ref().map(|token_address| info_provider.token_info(&token_address).ok()).flatten();
         Ok(TransactionDetails {
             executed_at: self.execution_date.map(|data| data.timestamp_millis()),
             tx_status: self.map_status(&safe_info),
@@ -63,9 +54,9 @@ impl MultisigTransaction {
                 .collect(),
             refund_receiver: self.refund_receiver.as_ref().unwrap_or(&String::from("0x0000000000000000000000000000000000000000")).to_owned(),
             gas_token: self.gas_token.as_ref().unwrap_or(&String::from("0x0000000000000000000000000000000000000000")).to_owned(),
-            base_gas: self.base_gas,
-            safe_tx_gas: self.safe_tx_gas,
-            gas_price: self.gas_price.to_owned(),
+            base_gas: self.base_gas.unwrap_or(0),
+            safe_tx_gas: self.safe_tx_gas.unwrap_or(0),
+            gas_price: self.gas_price.as_ref().unwrap_or(&String::from("0")).to_owned(),
             gas_token_info: gas_token_info,
         }
     }

--- a/src/models/converters/transactions/details.rs
+++ b/src/models/converters/transactions/details.rs
@@ -2,12 +2,9 @@ extern crate chrono;
 
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::models::commons::Operation;
-use crate::models::service::transactions::details::{
-    DetailedExecutionInfo, ModuleExecutionDetails, MultisigConfirmation, MultisigExecutionDetails,
-    TransactionData, TransactionDetails,
-};
+use crate::models::service::transactions::details::{DetailedExecutionInfo, ModuleExecutionDetails, MultisigConfirmation, MultisigExecutionDetails, TransactionData, TransactionDetails, SignatureInfo};
 use crate::models::service::transactions::TransactionStatus;
-use crate::providers::info::InfoProvider;
+use crate::providers::info::{InfoProvider, SafeInfo, TokenInfo};
 use anyhow::Result;
 
 impl MultisigTransaction {
@@ -16,6 +13,7 @@ impl MultisigTransaction {
         info_provider: &mut dyn InfoProvider,
     ) -> Result<TransactionDetails> {
         let safe_info = info_provider.safe_info(&self.safe.to_string())?;
+        let gas_token = self.gas_token.as_ref().map(|token_address| info_provider.token_info(&token_address).ok()).flatten();
         Ok(TransactionDetails {
             executed_at: self.execution_date.map(|data| data.timestamp_millis()),
             tx_status: self.map_status(&safe_info),
@@ -28,30 +26,44 @@ impl MultisigTransaction {
                 operation: self.operation.unwrap_or(Operation::CALL),
             }),
             tx_hash: self.transaction_hash.as_ref().map(|hash| hash.to_owned()),
-            detailed_execution_info: Some(DetailedExecutionInfo::Multisig(
-                MultisigExecutionDetails {
-                    submitted_at: self.submission_date.timestamp_millis(),
-                    nonce: self.nonce,
-                    safe_tx_hash: self.safe_tx_hash.to_owned(),
-                    executor: self.executor.to_owned(),
-                    signers: safe_info.owners,
-                    confirmations_required: self
-                        .confirmations_required
-                        .unwrap_or(safe_info.threshold),
-                    confirmations: self
-                        .confirmations
-                        .as_ref()
-                        .unwrap_or(&vec![])
-                        .into_iter()
-                        .map(|confirmation| MultisigConfirmation {
-                            signer: confirmation.owner.to_owned(),
-                            signature: confirmation.signature.to_owned(),
-                            submitted_at: confirmation.submission_date.timestamp_millis(),
-                        })
-                        .collect(),
-                },
-            )),
+            detailed_execution_info: Some(DetailedExecutionInfo::Multisig(self.build_execution_details(safe_info, gas_token))),
         })
+    }
+
+    fn build_execution_details(&self, safe_info: SafeInfo, gas_token: Option<TokenInfo>) -> MultisigExecutionDetails {
+        MultisigExecutionDetails {
+            submitted_at: self.submission_date.timestamp_millis(),
+            nonce: self.nonce,
+            safe_tx_hash: self.safe_tx_hash.to_owned(),
+            executor: self.executor.to_owned(),
+            signers: safe_info.owners,
+            confirmations_required: self
+                .confirmations_required
+                .unwrap_or(safe_info.threshold),
+            confirmations: self
+                .confirmations
+                .as_ref()
+                .unwrap_or(&vec![])
+                .into_iter()
+                .map(|confirmation| MultisigConfirmation {
+                    signer: confirmation.owner.to_owned(),
+                    signature: confirmation.signature.to_owned(),
+                    submitted_at: confirmation.submission_date.timestamp_millis(),
+                })
+                .collect(),
+            signature_info: Some(self.build_signature_info(gas_token)),
+        }
+    }
+
+    fn build_signature_info(&self, gas_token: Option<TokenInfo>) -> SignatureInfo {
+        SignatureInfo {
+            refund_receiver: self.refund_receiver.to_owned(),
+            base_gas: self.base_gas,
+            safe_tx_gas: self.safe_tx_gas,
+            gas_limit: self.gas_price.to_owned(),
+            gas_token: gas_token.as_ref().map(|it| it.address.to_owned()).unwrap_or(String::from("0x0000000000000000000000000000000000000000")),
+            gas_token_info: gas_token,
+        }
     }
 }
 

--- a/src/models/converters/transactions/tests/details.rs
+++ b/src/models/converters/transactions/tests/details.rs
@@ -20,8 +20,8 @@ fn multisig_custom_transaction_to_transaction_details() {
         .return_once(move |_| Ok(safe_info));
     mock_info_provider
         .expect_token_info()
-        .times(1)
-        .return_once(move |_| Err(anyhow::anyhow!("No token info")));
+        .times(2)
+        .returning(move |_| anyhow::bail!("Token Address 0x0"));
 
     let expected = TransactionDetails {
         executed_at: multisig_tx.execution_date.map(|it| it.timestamp_millis()),
@@ -59,6 +59,11 @@ fn multisig_custom_transaction_to_transaction_details() {
             MultisigExecutionDetails {
                 submitted_at: multisig_tx.submission_date.timestamp_millis(),
                 nonce: 84,
+                safe_tx_gas: 43485,
+                base_gas: 0,
+                gas_price: "0".to_string(),
+                gas_token: "0x0000000000000000000000000000000000000000".to_string(),
+                refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
                 safe_tx_hash: "0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621".to_string(),
                 executor: Some("0xF2CeA96575d6b10f51d9aF3b10e3e4E5738aa6bd".to_string()),
                 signers: vec![
@@ -80,6 +85,7 @@ fn multisig_custom_transaction_to_transaction_details() {
                         submitted_at: timestamp_confirmation1,
                     },
                 ],
+                gas_token_info: None
             })),
     };
 

--- a/src/models/service/transactions/details.rs
+++ b/src/models/service/transactions/details.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use super::*;
 use crate::models::commons::{Operation, DataDecoded};
+use crate::providers::info::TokenInfo;
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +31,19 @@ pub struct MultisigExecutionDetails {
     pub signers: Vec<String>,
     pub confirmations_required: u64,
     pub confirmations: Vec<MultisigConfirmation>,
+    pub signature_info: Option<SignatureInfo>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureInfo {
+    pub refund_receiver: Option<String>,
+    pub base_gas: Option<usize>,
+    pub safe_tx_gas: Option<usize>,
+    pub gas_limit: Option<String>,
+    pub gas_token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_token_info: Option<TokenInfo>,
 }
 
 #[derive(Serialize, Debug, PartialEq)]

--- a/src/models/service/transactions/details.rs
+++ b/src/models/service/transactions/details.rs
@@ -26,16 +26,16 @@ pub enum DetailedExecutionInfo {
 pub struct MultisigExecutionDetails {
     pub submitted_at: i64,
     pub nonce: u64,
+    pub safe_tx_gas: usize,
+    pub base_gas: usize,
+    pub gas_price: String,
+    pub gas_token: String,
+    pub refund_receiver: String,
     pub safe_tx_hash: String,
     pub executor: Option<String>,
     pub signers: Vec<String>,
     pub confirmations_required: u64,
     pub confirmations: Vec<MultisigConfirmation>,
-    pub refund_receiver: String,
-    pub gas_token: String,
-    pub base_gas: Option<usize>,
-    pub safe_tx_gas: Option<usize>,
-    pub gas_price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_token_info: Option<TokenInfo>,
 }

--- a/src/models/service/transactions/details.rs
+++ b/src/models/service/transactions/details.rs
@@ -31,17 +31,11 @@ pub struct MultisigExecutionDetails {
     pub signers: Vec<String>,
     pub confirmations_required: u64,
     pub confirmations: Vec<MultisigConfirmation>,
-    pub signature_info: Option<SignatureInfo>,
-}
-
-#[derive(Serialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct SignatureInfo {
-    pub refund_receiver: Option<String>,
+    pub refund_receiver: String,
+    pub gas_token: String,
     pub base_gas: Option<usize>,
     pub safe_tx_gas: Option<usize>,
-    pub gas_limit: Option<String>,
-    pub gas_token: String,
+    pub gas_price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_token_info: Option<TokenInfo>,
 }

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -10,8 +10,8 @@ use mockall::automock;
 
 #[automock]
 pub trait InfoProvider {
-    fn safe_info(&mut self, safe: &String) -> Result<SafeInfo>;
-    fn token_info(&mut self, token: &String) -> Result<TokenInfo>;
+    fn safe_info(&mut self, safe: &str) -> Result<SafeInfo>;
+    fn token_info(&mut self, token: &str) -> Result<TokenInfo>;
 }
 
 pub struct DefaultInfoProvider<'p> {
@@ -51,14 +51,18 @@ pub struct TokenInfo {
 }
 
 impl InfoProvider for DefaultInfoProvider<'_> {
-    fn safe_info(&mut self, safe: &String) -> Result<SafeInfo> {
+    fn safe_info(&mut self, safe: &str) -> Result<SafeInfo> {
         let url = format!("{}/safes/{}/", base_transaction_service_url(), safe);
         self.cached(|this| &mut this.safe_cache, url)
     }
 
-    fn token_info(&mut self, token: &String) -> Result<TokenInfo> {
-        let url = format!("{}/tokens/{}/", base_transaction_service_url(), token);
-        self.cached(|this| &mut this.token_cache, url)
+    fn token_info(&mut self, token: &str) -> Result<TokenInfo> {
+        if token != "0x0000000000000000000000000000000000000000" {
+            let url = format!("{}/tokens/{}/", base_transaction_service_url(), token);
+            self.cached(|this| &mut this.token_cache, url)
+        } else {
+            anyhow::bail!("Token Address is 0x0")
+        }
     }
 }
 


### PR DESCRIPTION
Closes #53 
- Added fields for signing transactions (in the required order) as part of the `MultsigExecutionDetails`
- Adding gas token info optionally, when available