### PR TITLE
Closes #114 Method name for custom transactions in summary

### DIFF
--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -179,6 +179,7 @@ impl MultisigTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap().into(),
+            data_decoded: self.data_decoded.to_owned(),
         }
     }
 }
@@ -189,6 +190,7 @@ impl ModuleTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap_or(&String::from("0")).clone(),
+            data_decoded: self.data_decoded.to_owned(),
         })
     }
 }

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -179,7 +179,7 @@ impl MultisigTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap().into(),
-            data_decoded: self.data_decoded.to_owned(),
+            method_name: self.data_decoded.as_ref().map(|it| it.method.clone()),
         }
     }
 }
@@ -190,7 +190,7 @@ impl ModuleTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap_or(&String::from("0")).clone(),
-            data_decoded: self.data_decoded.to_owned(),
+            method_name: self.data_decoded.as_ref().map(|it| it.method.clone()),
         })
     }
 }

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -179,7 +179,7 @@ impl MultisigTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap().into(),
-            method_name: self.data_decoded.as_ref().map(|it| it.method.clone()),
+            method_name: self.data_decoded.as_ref().map(|it| it.method.to_owned()),
         }
     }
 }
@@ -190,7 +190,7 @@ impl ModuleTransaction {
             to: self.to.to_owned(),
             data_size: data_size(&self.data),
             value: self.value.as_ref().unwrap_or(&String::from("0")).clone(),
-            method_name: self.data_decoded.as_ref().map(|it| it.method.clone()),
+            method_name: self.data_decoded.as_ref().map(|it| it.method.to_owned()),
         })
     }
 }

--- a/src/models/converters/transactions/tests/details.rs
+++ b/src/models/converters/transactions/tests/details.rs
@@ -31,6 +31,23 @@ fn multisig_custom_transaction_to_transaction_details() {
             to: "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02".to_string(),
             data_size: "68".to_string(),
             value: "0".to_string(),
+            data_decoded: Some(DataDecoded {
+                method: "approve".to_string(),
+                parameters: Some(vec![
+                    Parameter {
+                        name: "spender".to_string(),
+                        param_type: "address".to_string(),
+                        value: SingleValue(String::from("0xae9844F89D98c150F5e61bfC676D68b492155990")),
+                        value_decoded: None,
+                    },
+                    Parameter {
+                        name: "value".to_string(),
+                        param_type: "uint256".to_string(),
+                        value: SingleValue(String::from("500000000000000")),
+                        value_decoded: None,
+                    }
+                ]),
+            }),
         }),
         tx_data: Some(TransactionData {
             hex_data: Some(String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000")),
@@ -100,6 +117,7 @@ fn module_transaction_to_transaction_details() {
             to: "0xaAEb2035FF394fdB2C879190f95e7676f1A9444B".to_string(),
             data_size: "132".to_string(),
             value: "0".to_string(),
+            data_decoded: None
         }),
         tx_data: Some(TransactionData {
             hex_data: Some(String::from("0x59f96ae500000000000000000000000000df91984582e6e96288307e9c2f20b38c8fece9000000000000000000000000c778417e063141139fce010982780140aa0cd5ab0000000000000000000000000000000000000000000000000000000000000475000000000000000000000000000000000000000000000003d962c8be3053def2")),

--- a/src/models/converters/transactions/tests/details.rs
+++ b/src/models/converters/transactions/tests/details.rs
@@ -31,23 +31,7 @@ fn multisig_custom_transaction_to_transaction_details() {
             to: "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02".to_string(),
             data_size: "68".to_string(),
             value: "0".to_string(),
-            data_decoded: Some(DataDecoded {
-                method: "approve".to_string(),
-                parameters: Some(vec![
-                    Parameter {
-                        name: "spender".to_string(),
-                        param_type: "address".to_string(),
-                        value: SingleValue(String::from("0xae9844F89D98c150F5e61bfC676D68b492155990")),
-                        value_decoded: None,
-                    },
-                    Parameter {
-                        name: "value".to_string(),
-                        param_type: "uint256".to_string(),
-                        value: SingleValue(String::from("500000000000000")),
-                        value_decoded: None,
-                    }
-                ]),
-            }),
+            method_name: Some("approve".to_string()),
         }),
         tx_data: Some(TransactionData {
             hex_data: Some(String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000")),
@@ -117,7 +101,7 @@ fn module_transaction_to_transaction_details() {
             to: "0xaAEb2035FF394fdB2C879190f95e7676f1A9444B".to_string(),
             data_size: "132".to_string(),
             value: "0".to_string(),
-            data_decoded: None
+            method_name: None,
         }),
         tx_data: Some(TransactionData {
             hex_data: Some(String::from("0x59f96ae500000000000000000000000000df91984582e6e96288307e9c2f20b38c8fece9000000000000000000000000c778417e063141139fce010982780140aa0cd5ab0000000000000000000000000000000000000000000000000000000000000475000000000000000000000000000000000000000000000003d962c8be3053def2")),

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -66,7 +66,7 @@ fn module_tx_to_summary_transaction() {
                     to: expected_to,
                     data_size: String::from("0"),
                     value: String::from("0"),
-                    data_decoded: None,
+                    method_name: None,
                 }),
         });
     assert_eq!(actual, expected);
@@ -410,25 +410,10 @@ fn multisig_transaction_to_custom_summary() {
             to: "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02".to_string(),
             data_size: "68".to_string(),
             value: "0".to_string(),
-            data_decoded: Some(DataDecoded {
-                method: "approve".to_string(),
-                parameters: Some(vec![
-                    Parameter {
-                        name: "spender".to_string(),
-                        param_type: "address".to_string(),
-                        value: SingleValue(String::from("0xae9844F89D98c150F5e61bfC676D68b492155990")),
-                        value_decoded: None,
-                    },
-                    Parameter {
-                        name: "value".to_string(),
-                        param_type: "uint256".to_string(),
-                        value: SingleValue(String::from("500000000000000")),
-                        value_decoded: None,
-                    }
-                ]),
-            }),
+            method_name: Some("approve".to_string()),
         }),
-        execution_info: Some(ExecutionInfo {
+        execution_info: Some(ExecutionInfo
+        {
             nonce: 84,
             confirmations_required: 2,
             confirmations_submitted: 2,

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -66,6 +66,7 @@ fn module_tx_to_summary_transaction() {
                     to: expected_to,
                     data_size: String::from("0"),
                     value: String::from("0"),
+                    data_decoded: None,
                 }),
         });
     assert_eq!(actual, expected);
@@ -409,6 +410,23 @@ fn multisig_transaction_to_custom_summary() {
             to: "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02".to_string(),
             data_size: "68".to_string(),
             value: "0".to_string(),
+            data_decoded: Some(DataDecoded {
+                method: "approve".to_string(),
+                parameters: Some(vec![
+                    Parameter {
+                        name: "spender".to_string(),
+                        param_type: "address".to_string(),
+                        value: SingleValue(String::from("0xae9844F89D98c150F5e61bfC676D68b492155990")),
+                        value_decoded: None,
+                    },
+                    Parameter {
+                        name: "value".to_string(),
+                        param_type: "uint256".to_string(),
+                        value: SingleValue(String::from("500000000000000")),
+                        value_decoded: None,
+                    }
+                ]),
+            }),
         }),
         execution_info: Some(ExecutionInfo {
             nonce: 84,

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -129,7 +129,7 @@ pub struct Custom {
     pub to: String,
     pub data_size: String,
     pub value: String,
-    pub data_decoded: Option<DataDecoded>,
+    pub method_name: Option<String>,
 }
 
 #[derive(Serialize, Debug, PartialEq)]

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -129,6 +129,7 @@ pub struct Custom {
     pub to: String,
     pub data_size: String,
     pub value: String,
+    pub data_decoded: Option<DataDecoded>,
 }
 
 #[derive(Serialize, Debug, PartialEq)]


### PR DESCRIPTION
Closes #114 

- Including `data_decoded` in Custom `TransactionInfo` to have access to method name and params