### PR TITLE
Closes #142 Null decimals in TokenInfo handled

### DIFF
--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use mockall::automock;
+use crate::utils::json::default_if_null;
 
 #[automock]
 pub trait InfoProvider {
@@ -44,6 +45,7 @@ pub struct TokenInfo {
     #[serde(rename = "type")]
     pub token_type: TokenType,
     pub address: String,
+    #[serde(deserialize_with = "default_if_null")]
     pub decimals: u64,
     pub symbol: String,
     pub name: String,

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -1,13 +1,13 @@
 use crate::utils::cache::{Cache, CacheExt};
 use crate::config::{base_transaction_service_url, info_cache_duration};
 use crate::utils::context::Context;
+use crate::utils::json::default_if_null;
 use serde_json;
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use mockall::automock;
-use crate::utils::json::default_if_null;
 
 #[automock]
 pub trait InfoProvider {

--- a/src/utils/json.rs
+++ b/src/utils/json.rs
@@ -7,3 +7,11 @@ pub fn try_deserialize<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error
 {
     Ok(T::deserialize(deserializer).ok())
 }
+
+pub fn default_if_null<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        T: Default + serde::Deserialize<'de>,
+{
+    <Option<T> as serde::Deserialize>::deserialize(deserializer).map(|result| result.unwrap_or_default())
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,9 +12,6 @@ pub mod errors;
 #[cfg(test)]
 mod tests;
 
-#[cfg(test)]
-mod tests;
-
 //TODO think of a better impl, using enums as per Nick's suggestion
 pub const TRANSFER_METHOD: &str = "transfer";
 pub const ERC20_TRANSFER_METHODS: &[&str] = &[TRANSFER_METHOD, "transferFrom"];

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,9 @@ pub mod context;
 pub mod cache;
 pub mod json;
 
+#[cfg(test)]
+mod tests;
+
 //TODO think of a better impl, using enums as per Nick's suggestion
 pub const TRANSFER_METHOD: &str = "transfer";
 pub const ERC20_TRANSFER_METHODS: &[&str] = &[TRANSFER_METHOD, "transferFrom"];

--- a/src/utils/tests/json.rs
+++ b/src/utils/tests/json.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 #[derive(PartialEq, Deserialize, Debug)]
 struct ExpectedStruct {
     #[serde(deserialize_with = "default_if_null")]
-    field: String,
+    field: u64,
     other_field: String,
     #[serde(deserialize_with = "default_if_null")]
     with_custom_default: WithCustomDefault,
@@ -39,7 +39,7 @@ fn deserialize_expected_field_null() {
     });
 
     let expected = ExpectedStruct {
-        field: "".to_string(),
+        field: 0,
         other_field: "other value".to_string(),
         with_custom_default: WithCustomDefault("different value".to_string()),
     };
@@ -52,13 +52,13 @@ fn deserialize_expected_field_null() {
 #[test]
 fn deserialize_expected_field_with_value() {
     let test_json = json!({
-        "field" : "value",
+        "field" : 42,
         "other_field":"other value",
         "with_custom_default": "different value"
     });
 
     let expected = ExpectedStruct {
-        field: "value".to_string(),
+        field: 42,
         other_field: "other value".to_string(),
         with_custom_default: WithCustomDefault("different value".to_string()),
     };
@@ -71,13 +71,13 @@ fn deserialize_expected_field_with_value() {
 #[test]
 fn deserialize_expected_field_with_custom_default() {
     let test_json = json!({
-        "field" : "value",
+        "field" : 42,
         "other_field":"other value",
         "with_custom_default": null
     });
 
     let expected = ExpectedStruct {
-        field: "value".to_string(),
+        field: 42,
         other_field: "other value".to_string(),
         with_custom_default: WithCustomDefault("custom default".to_string()),
     };

--- a/src/utils/tests/json.rs
+++ b/src/utils/tests/json.rs
@@ -1,0 +1,88 @@
+use crate::utils::json::default_if_null;
+use serde::Deserialize;
+
+
+#[derive(PartialEq, Deserialize, Debug)]
+struct ExpectedStruct {
+    #[serde(deserialize_with = "default_if_null")]
+    field: String,
+    other_field: String,
+    #[serde(deserialize_with = "default_if_null")]
+    with_custom_default: WithCustomDefault,
+}
+
+#[derive(PartialEq, Deserialize, Debug)]
+struct WithCustomDefault(String);
+
+impl Default for WithCustomDefault {
+    fn default() -> Self {
+        WithCustomDefault("custom default".to_string())
+    }
+}
+
+#[test]
+#[should_panic]
+fn deserialize_missing_expected_field() {
+    let test_json = json!({
+        "other_field":"other value"
+    });
+
+    serde_json::from_str::<ExpectedStruct>(&test_json.to_string()).unwrap();
+}
+
+#[test]
+fn deserialize_expected_field_null() {
+    let test_json = json!({
+        "field" : null,
+        "other_field":"other value",
+        "with_custom_default": "different value"
+    });
+
+    let expected = ExpectedStruct {
+        field: "".to_string(),
+        other_field: "other value".to_string(),
+        with_custom_default: WithCustomDefault("different value".to_string()),
+    };
+
+    let actual = serde_json::from_str::<ExpectedStruct>(&test_json.to_string()).unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn deserialize_expected_field_with_value() {
+    let test_json = json!({
+        "field" : "value",
+        "other_field":"other value",
+        "with_custom_default": "different value"
+    });
+
+    let expected = ExpectedStruct {
+        field: "value".to_string(),
+        other_field: "other value".to_string(),
+        with_custom_default: WithCustomDefault("different value".to_string()),
+    };
+
+    let actual = serde_json::from_str::<ExpectedStruct>(&test_json.to_string()).unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn deserialize_expected_field_with_custom_default() {
+    let test_json = json!({
+        "field" : "value",
+        "other_field":"other value",
+        "with_custom_default": null
+    });
+
+    let expected = ExpectedStruct {
+        field: "value".to_string(),
+        other_field: "other value".to_string(),
+        with_custom_default: WithCustomDefault("custom default".to_string()),
+    };
+
+    let actual = serde_json::from_str::<ExpectedStruct>(&test_json.to_string()).unwrap();
+
+    assert_eq!(expected, actual);
+}

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,0 +1,1 @@
+mod json;


### PR DESCRIPTION
Closes #142
- Default on null value deserialiser added to JSON utils
- Any other default value required for a specific type can be add by implementing the `Default` trait for said type 