### PR TITLE
Closes #127 Introduction of health endpoint

### DIFF
--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,9 +1,10 @@
 use crate::utils::context::Context;
-use crate::config::request_cache_duration;
 use crate::utils::cache::CacheExt;
 use crate::utils::errors::ApiResult;
+use crate::config::request_cache_duration;
+use rocket::response::content;
 
 #[get("/health")]
-pub fn health(context: Context) -> ApiResult<String> {
-    context.cache().cache_string("/health", request_cache_duration())
+pub fn health(context: Context) -> ApiResult<content::Json<String>> {
+    context.cache().cache_resp("/health", request_cache_duration(), || Ok(String::new()))
 }

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,0 +1,10 @@
+use crate::utils::context::Context;
+use crate::config::{about_cache_duration, base_transaction_service_url};
+use crate::utils::cache::CacheExt;
+use crate::utils::errors::ApiResult;
+
+#[get("/health")]
+pub fn health(context: Context) -> ApiResult<String> {
+    let url = format!("{}/about", base_transaction_service_url());
+    context.cache().request_cached(context.client(), &url, about_cache_duration())
+}

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,10 +1,9 @@
 use crate::utils::context::Context;
-use crate::config::{about_cache_duration, base_transaction_service_url};
+use crate::config::request_cache_duration;
 use crate::utils::cache::CacheExt;
 use crate::utils::errors::ApiResult;
 
 #[get("/health")]
 pub fn health(context: Context) -> ApiResult<String> {
-    let url = format!("{}/about", base_transaction_service_url());
-    context.cache().request_cached(context.client(), &url, about_cache_duration())
+    context.cache().cache_string("/health", request_cache_duration())
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -7,9 +7,10 @@ use rocket_contrib::json::JsonValue;
 pub mod about;
 pub mod transactions;
 pub mod hooks;
+pub mod health;
 
 pub fn active_routes() -> Vec<Route> {
-    routes![about::backbone, about::info, transactions::details, transactions::all, hooks::update]
+    routes![about::backbone, about::info, transactions::details, transactions::all, hooks::update, health::health]
 }
 
 pub fn error_catchers() -> Vec<Catcher> {
@@ -23,6 +24,7 @@ fn not_found() -> JsonValue {
         "reason": "Resource was not found."
     })
 }
+
 #[catch(500)]
 fn panic() -> JsonValue {
     json!({

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -85,22 +85,6 @@ pub trait CacheExt: Cache {
             }
         }
     }
-
-    fn cache_string(
-        &self,
-        key: &str,
-        timeout: usize,
-    ) -> ApiResult<String> {
-        let cached = self.fetch(key);
-        match cached {
-            Some(value) => Ok(value),
-            None => {
-                let to_cache = String::new();
-                self.create(key, to_cache.as_str(), timeout);
-                Ok(to_cache)
-            }
-        }
-    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -85,6 +85,22 @@ pub trait CacheExt: Cache {
             }
         }
     }
+
+    fn cache_string(
+        &self,
+        key: &str,
+        timeout: usize,
+    ) -> ApiResult<String> {
+        let cached = self.fetch(key);
+        match cached {
+            Some(value) => Ok(value),
+            None => {
+                let to_cache = String::new();
+                self.create(key, to_cache.as_str(), timeout);
+                Ok(to_cache)
+            }
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -40,7 +40,7 @@ impl Cache for ServiceCache {
 pub trait CacheExt: Cache {
     fn cache_resp<R>(
         &self,
-        key: &String,
+        key: &str,
         timeout: usize,
         resp: impl Fn() -> ApiResult<R>,
     ) -> ApiResult<content::Json<String>>
@@ -60,7 +60,7 @@ pub trait CacheExt: Cache {
     fn request_cached(
         &self,
         client: &reqwest::blocking::Client,
-        url: &String,
+        url: &str,
         timeout: usize,
     ) -> ApiResult<String> {
         match self.fetch(&url) {


### PR DESCRIPTION
Closes #127 
- ~~Health endpoint caches the response from `/about` endpoint of the transaction service and returns it~~
- Health endpoint caches and responds with the value from the`("/health", "")` key value pair 