### PR TITLE
Closes #153: Update version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "0.2.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cargo-watch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "0.2.0"
+version = "1.2.0"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Set version number to 1.2.0

This does not affect the version number returned by the `about` endpoint as this one is based on the GitHub tag.