### PR TITLE
Perf logs 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod config;
 mod routes;
 mod services;
 mod models;
+mod monitoring;
 mod utils;
 mod providers;
 
@@ -32,10 +33,11 @@ use crate::routes::error_catchers;
 fn main() {
     dotenv().ok();
     env_logger::init();
-    
+
     rocket::ignite()
         .mount("/", active_routes())
         .manage(reqwest::blocking::Client::new())
+        .attach(monitoring::request_timer::RequestTimer())
         .attach(CORS())
         .attach(ServiceCache::fairing())
         .register(error_catchers())

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -1,0 +1,1 @@
+pub mod request_timer;

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -21,10 +21,10 @@ impl Fairing for RequestTimer {
     }
 
     fn on_response(&self, request: &Request, _response: &mut Response) {
-        let h = request.headers().get("requested_timestamp").next().unwrap().parse::<i64>().unwrap();
-        let instant = Utc::now().timestamp_millis();
-
-        let delta = instant - h;
-        log::debug!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
+        if let Some(requested_timestamp) = request.headers().get("requested_timestamp").next().map(|it| it.parse::<i64>().ok()).flatten() {
+            let instant = Utc::now().timestamp_millis();
+            let delta = instant - requested_timestamp;
+            log::debug!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
+        }
     }
 }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -13,15 +13,15 @@ impl Fairing for RequestTimer {
     }
 
     fn on_request(&self, request: &mut Request, _data: &Data) {
-        let instant = Utc::now().timestamp_millis();
-        log::info!("on_request: {}", &instant);
-        request.local_cache(|| instant);
+        let instant = Utc::now();
+        log::info!("on_request: {}", &instant.to_rfc3339());
+        request.local_cache(|| instant.timestamp_millis());
     }
 
     fn on_response(&self, request: &Request, _response: &mut Response) {
-        let instant = Utc::now().timestamp_millis();
-        log::info!("on_response: {}", &instant);
-        let cached = request.local_cache(|| instant).to_owned();
+        let instant = Utc::now();
+        log::info!("on_response: {}", &instant.to_rfc3339());
+        let cached = request.local_cache(|| instant.timestamp_millis()).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
         log::info!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
     }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -20,6 +20,6 @@ impl Fairing for RequestTimer {
         let path_data = request.route().map(|route| route.uri.to_string()).unwrap_or(String::from(request.uri().path()));
         let cached = request.local_cache(|| Utc::now().timestamp_millis()).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
-        log::info!("request_time::{}::{}",path_data , delta)
+        log::info!("response_time::{}::{}",path_data , delta)
     }
 }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -14,13 +14,15 @@ impl Fairing for RequestTimer {
 
     fn on_request(&self, request: &mut Request, _data: &Data) {
         let instant = Utc::now().timestamp_millis();
-        log::debug!("on_request: {}", &instant);
-        request.local_cache(|| Utc::now().timestamp_millis());
+        log::info!("on_request: {}", &instant);
+        request.local_cache(|| instant);
     }
 
     fn on_response(&self, request: &Request, _response: &mut Response) {
-        let cached = request.local_cache(|| Utc::now().timestamp_millis()).to_owned();
+        let instant = Utc::now().timestamp_millis();
+        log::info!("on_response: {}", &instant);
+        let cached = request.local_cache(|| instant).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
-        log::debug!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
+        log::info!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
     }
 }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -17,8 +17,9 @@ impl Fairing for RequestTimer {
     }
 
     fn on_response(&self, request: &Request, _response: &mut Response) {
+        let path_data = request.route().map(|route| route.uri.to_string()).unwrap_or(String::from(request.uri().path()));
         let cached = request.local_cache(|| Utc::now().timestamp_millis()).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
-        log::info!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
+        log::info!("request_time::{}::{}",path_data , delta)
     }
 }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -20,6 +20,6 @@ impl Fairing for RequestTimer {
         let path_data = request.route().map(|route| route.uri.to_string()).unwrap_or(String::from(request.uri().path()));
         let cached = request.local_cache(|| Utc::now().timestamp_millis()).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
-        log::info!("response_time::{}::{}",path_data , delta)
+        log::info!("response_time_ms::{}::{}",path_data , delta)
     }
 }

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -1,0 +1,30 @@
+use rocket::fairing::{Fairing, Info, Kind};
+use chrono::Utc;
+use rocket::{Request, Response, Data};
+use rocket::http::Header;
+
+pub struct RequestTimer();
+
+impl Fairing for RequestTimer {
+    fn info(&self) -> Info {
+        Info {
+            name: "RequestTimer",
+            kind: Kind::Request | Kind::Response,
+        }
+    }
+
+    fn on_request(&self, request: &mut Request, _data: &Data) {
+        let instant = Utc::now().timestamp_millis();
+        log::debug!("on_request: {}", &instant);
+        let h = Header::new("requested_timestamp", instant.to_string());
+        request.add_header(h)
+    }
+
+    fn on_response(&self, request: &Request, _response: &mut Response) {
+        let h = request.headers().get("requested_timestamp").next().unwrap().parse::<i64>().unwrap();
+        let instant = Utc::now().timestamp_millis();
+
+        let delta = instant - h;
+        log::debug!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
+    }
+}

--- a/src/monitoring/request_timer.rs
+++ b/src/monitoring/request_timer.rs
@@ -13,15 +13,11 @@ impl Fairing for RequestTimer {
     }
 
     fn on_request(&self, request: &mut Request, _data: &Data) {
-        let instant = Utc::now();
-        log::info!("on_request: {}", &instant.to_rfc3339());
-        request.local_cache(|| instant.timestamp_millis());
+        request.local_cache(|| Utc::now().timestamp_millis());
     }
 
     fn on_response(&self, request: &Request, _response: &mut Response) {
-        let instant = Utc::now();
-        log::info!("on_response: {}", &instant.to_rfc3339());
-        let cached = request.local_cache(|| instant.timestamp_millis()).to_owned();
+        let cached = request.local_cache(|| Utc::now().timestamp_millis()).to_owned();
         let delta = Utc::now().timestamp_millis() - cached;
         log::info!("For endpoint {} the request processing duration was {} [ms]", request.uri().path(), delta)
     }


### PR DESCRIPTION
Closes #147 

- Using request's `local_cache` to store the timestamp of when the request was received