### PR TITLE
Update /transactions to /multisig-transactions backend endpoint 

### DIFF
--- a/src/models/converters/transactions/tests/mod.rs
+++ b/src/models/converters/transactions/tests/mod.rs
@@ -3,5 +3,6 @@ mod data_size_calculation;
 mod details;
 pub(super) mod map_status;
 pub(super) mod missing_signers;
+mod summary;
 pub(super) mod transaction_types;
 pub(super) mod transfer_type_checks;

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -23,7 +23,7 @@ pub(super) fn get_multisig_transaction_details(
 ) -> ApiResult<TransactionDetails> {
     let mut info_provider = DefaultInfoProvider::new(context);
     let url = format!(
-        "{}/v1/transactions/{}",
+        "{}/v1/multisig-transactions/{}",
         base_transaction_service_url(),
         safe_tx_hash
     );


### PR DESCRIPTION
Closes #165 

- Changed endpoint for multisig tx details endpoint to `/multisig-transactions`
- restored missing `details` test module causing the test coverage crash (partly)