### PR TITLE
Version bump for 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - nightly
+  - nightly-2020-10-24
 
 cache:
   - cargo
@@ -14,7 +14,7 @@ services:
   - docker
 
 script:
-  - rustup component add rustfmt --allow-downgrade
+  - rustup component add rustfmt
   - cargo fmt --all -- --check || travis_terminate 1;  # Check formatting
   # These flags are recommended by https://github.com/mozilla/grcov#grcov-with-travis .
   # vk: I had to remove `-Zpanic_abort_tests -Cpanic=abort` because this would cause compilation

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - docker
 
 script:
-  - rustup --allow-downgrade component add rustfmt
+  - rustup component add rustfmt --allow-downgrade
   - cargo fmt --all -- --check || travis_terminate 1;  # Check formatting
   # These flags are recommended by https://github.com/mozilla/grcov#grcov-with-travis .
   # vk: I had to remove `-Zpanic_abort_tests -Cpanic=abort` because this would cause compilation

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - docker
 
 script:
-  - rustup component add rustfmt
+  - rustup --allow-downgrade component add rustfmt
   - cargo fmt --all -- --check || travis_terminate 1;  # Check formatting
   # These flags are recommended by https://github.com/mozilla/grcov#grcov-with-travis .
   # vk: I had to remove `-Zpanic_abort_tests -Cpanic=abort` because this would cause compilation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cargo-watch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Closes #173 

Note: the build process was interrupted because `rustfmt` was not available for the latest nightly build. There where 2 possible solutions for the problem:
- Add `--allow-downgrade` as described [here](https://github.com/actions-rs/toolchain/issues/53#issuecomment-603244046)
- Nightly version pinning. This has the added advantage of locking versions like it is done for dependencies. Any future potentially breaking changes are not used. For reference look at [this](https://github.com/travis-ci/travis-ci/issues/7167#issuecomment-405799816) and [this](https://github.com/crate-ci/example-clippy/blob/master/.travis.yml#L12)