### PR TITLE
Casing issues for History and Queued endpoints

### DIFF
--- a/src/models/service/transactions/summary.rs
+++ b/src/models/service/transactions/summary.rs
@@ -26,7 +26,7 @@ pub struct ExecutionInfo {
 pub enum TransactionListItem {
     #[serde(rename_all = "camelCase")]
     Transaction {
-        transaction_summary: TransactionSummary,
+        transaction: TransactionSummary,
         conflict_type: ConflictType,
     },
     DateLabel {
@@ -41,14 +41,12 @@ pub enum TransactionListItem {
 }
 
 #[derive(Serialize, Debug, PartialEq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Label {
     Next,
     Queued,
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
 pub enum ConflictType {
     None,
     HasNext,

--- a/src/models/service/transactions/summary.rs
+++ b/src/models/service/transactions/summary.rs
@@ -23,19 +23,22 @@ pub struct ExecutionInfo {
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[serde(tag = "tx_item_type")]
+#[serde(tag = "type")]
 pub enum TransactionListItem {
-    #[serde(rename(serialize = "TRANSACTION"))]
+    #[serde(rename_all = "camelCase")]
     Transaction {
         transaction_summary: TransactionSummary,
         conflict_type: ConflictType,
     },
-    #[serde(rename(serialize = "DATE_LABEL"))]
-    DateLabel { timestamp: i64 },
-    #[serde(rename(serialize = "LABEL"))]
-    Label { label: Label },
-    #[serde(rename(serialize = "CONFLICT_HEADER"))]
-    ConflictHeader { nonce: u64 },
+    DateLabel {
+        timestamp: i64,
+    },
+    Label {
+        label: Label,
+    },
+    ConflictHeader {
+        nonce: u64,
+    },
 }
 
 #[derive(Serialize, Debug, PartialEq)]

--- a/src/models/service/transactions/summary.rs
+++ b/src/models/service/transactions/summary.rs
@@ -23,6 +23,7 @@ pub struct ExecutionInfo {
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(tag = "type")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionListItem {
     #[serde(rename_all = "camelCase")]
     Transaction {

--- a/src/models/service/transactions/summary.rs
+++ b/src/models/service/transactions/summary.rs
@@ -22,7 +22,6 @@ pub struct ExecutionInfo {
 }
 
 #[derive(Serialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
 pub enum TransactionListItem {
     #[serde(rename_all = "camelCase")]

--- a/src/services/tests/transactions_history.rs
+++ b/src/services/tests/transactions_history.rs
@@ -240,30 +240,30 @@ fn service_txs_to_tx_list_items_last_timestamp_undefined() {
             timestamp: 1606780800000,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::DateLabel {
             timestamp: 1606694400000,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
     ];
@@ -289,30 +289,30 @@ fn service_txs_to_tx_list_items_last_timestamp_defined_but_different() {
             timestamp: 1606780800000,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::DateLabel {
             timestamp: 1606694400000,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
     ];
@@ -335,30 +335,30 @@ fn service_txs_to_tx_list_items_last_timestamp_defined_and_same() {
 
     let expected = vec![
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::DateLabel {
             timestamp: 1606694400000,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
         TransactionListItem::Transaction {
-            transaction_summary: service_txs_inter.next().unwrap(),
+            transaction: service_txs_inter.next().unwrap(),
             conflict_type: ConflictType::None,
         },
     ];

--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -151,7 +151,7 @@ pub(super) fn service_txs_to_tx_list_items(
         }
         transaction_group.for_each(|tx| {
             tx_list_items.push(TransactionListItem::Transaction {
-                transaction_summary: tx,
+                transaction: tx,
                 conflict_type: ConflictType::None,
             })
         });

--- a/src/services/transactions_queued.rs
+++ b/src/services/transactions_queued.rs
@@ -208,7 +208,7 @@ fn add_transation_as_summary(
                 conflict_type.clone()
             };
         items.push(TransactionListItem::Transaction {
-            transaction_summary: summary,
+            transaction: summary,
             conflict_type: tx_conflict_type,
         });
     }


### PR DESCRIPTION
- `tx_item_type` renamed to `type`
- Variants are capitalised under `type`