### PR TITLE
Added trusted and exclude_spam filter flags for forwarding

### DIFF
--- a/src/routes/collectibles.rs
+++ b/src/routes/collectibles.rs
@@ -5,12 +5,21 @@ use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 
-#[get("/v1/safes/<safe_address>/collectibles")]
-pub fn list(context: Context, safe_address: String) -> ApiResult<content::Json<String>> {
+#[get("/v1/safes/<safe_address>/collectibles?<trusted>&<exclude_spam>")]
+pub fn list(
+    context: Context,
+    safe_address: String,
+    trusted: Option<bool>,
+    exclude_spam: Option<bool>,
+) -> ApiResult<content::Json<String>> {
+    let trusted = trusted.unwrap_or(false);
+    let exclude_spam = exclude_spam.unwrap_or(true);
     let url = format!(
-        "{}/v1/safes/{}/collectibles",
+        "{}/v1/safes/{}/collectibles?trusted={}&exclude_spam={}",
         base_transaction_service_url(),
-        safe_address
+        safe_address,
+        trusted,
+        exclude_spam
     );
     Ok(content::Json(context.cache().request_cached(
         &context.client(),


### PR DESCRIPTION
Closes #207 

- Added `trusted` and `exclude_spam` filters
- Set `exclude_spam` to `true` and left `trusted` to default to the same value in the core services swagger (`false`)
