### PR TITLE
Added an endpoint returning  all supported fiat codes

### DIFF
--- a/src/routes/balances.rs
+++ b/src/routes/balances.rs
@@ -1,4 +1,5 @@
 use crate::config::request_cache_duration;
+use crate::providers::info::DefaultInfoProvider;
 use crate::services::balances::*;
 use crate::utils::cache::CacheExt;
 use crate::utils::context::Context;
@@ -25,5 +26,15 @@ pub fn get_balances(
                 trusted,
                 exclude_spam,
             )
+        })
+}
+
+#[get("/v1/balances/supported-fiat-codes")]
+pub fn get_supported_fiat(context: Context) -> ApiResult<content::Json<String>> {
+    context
+        .cache()
+        .cache_resp(&context.uri(), request_cache_duration(), || {
+            let info_provider = DefaultInfoProvider::new(&context);
+            Ok(info_provider.available_currency_codes()?)
         })
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -16,6 +16,7 @@ pub fn active_routes() -> Vec<Route> {
         about::backbone,
         about::info,
         balances::get_balances,
+        balances::get_supported_fiat,
         collectibles::list,
         transactions::details,
         transactions::all,


### PR DESCRIPTION
Closes #212 

- Endpoint `/v1/balances/supported-fiat-codes`
- Extracted method for `DefaultInfoProvider`
