### PR TITLE
POST Ether, ERC20 and ERC721 transfers only endpoint

### DIFF
--- a/src/models/backend/mod.rs
+++ b/src/models/backend/mod.rs
@@ -1,5 +1,6 @@
 pub mod about;
 pub mod balances;
+pub mod multisig_transaction_request;
 pub mod transactions;
 pub mod transfers;
 pub mod webhooks;

--- a/src/models/backend/multisig_transaction_request.rs
+++ b/src/models/backend/multisig_transaction_request.rs
@@ -1,0 +1,20 @@
+use crate::models::commons::Operation;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MultisigTransactionRequest {
+    pub to: String,
+    pub value: String,
+    pub data: String,
+    pub nonce: String,
+    pub operation: Operation,
+    pub safe_tx_gas: String,
+    pub base_gas: String,
+    pub gas_price: String,
+    pub gas_token: String,
+    pub refund_receiver: String,
+    pub contract_transaction_hash: String,
+    pub sender: String,
+    pub signature: String,
+}

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -2,6 +2,7 @@ extern crate chrono;
 
 pub mod details;
 pub mod safe_app_info;
+pub mod send_eth_request;
 pub mod summary;
 
 #[cfg(test)]

--- a/src/models/converters/transactions/send_eth_request.rs
+++ b/src/models/converters/transactions/send_eth_request.rs
@@ -1,23 +1,51 @@
 use crate::models::backend::multisig_transaction_request::MultisigTransactionRequest;
 use crate::models::commons::Operation;
-use crate::models::service::transactions::requests::SendEthRequest;
+use crate::models::service::transactions::requests::{
+    SendErc20Request, SendEthRequest, SendFundsRequest,
+};
 
-impl SendEthRequest {
+impl SendFundsRequest {
     pub fn to_multisig_transaction_request(&self) -> MultisigTransactionRequest {
+        match self {
+            SendFundsRequest::Ether(send_ether_request) => Self::send_ether(send_ether_request),
+            SendFundsRequest::Erc20(send_erc20_request) => {
+                Self::send_erc20_request(send_erc20_request)
+            }
+        }
+    }
+    fn send_ether(send_ether_request: &SendEthRequest) -> MultisigTransactionRequest {
         MultisigTransactionRequest {
-            to: self.receiver.to_string(),
-            value: self.value.to_string(),
-            data: self.data.to_string(),
-            nonce: self.nonce.to_string(),
+            to: send_ether_request.receiver.to_string(),
+            value: send_ether_request.value.to_string(),
+            data: "".to_string(),
+            nonce: send_ether_request.nonce.to_string(),
             operation: Operation::CALL,
             safe_tx_gas: "0".to_string(),
             base_gas: "0".to_string(),
             gas_price: "0".to_string(),
             gas_token: "0x0000000000000000000000000000000000000000".to_string(),
             refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
-            contract_transaction_hash: self.transaction_hash.to_string(),
-            sender: self.sender.to_string(),
-            signature: self.signed_transaction_hash.to_string(),
+            contract_transaction_hash: send_ether_request.transaction_hash.to_string(),
+            sender: send_ether_request.sender.to_string(),
+            signature: send_ether_request.signed_transaction_hash.to_string(),
+        }
+    }
+
+    fn send_erc20_request(send_erc20_request: &SendErc20Request) -> MultisigTransactionRequest {
+        MultisigTransactionRequest {
+            to: send_erc20_request.receiver.to_string(),
+            value: "0".to_string(),
+            data: send_erc20_request.data.to_string(),
+            nonce: send_erc20_request.nonce.to_string(),
+            operation: Operation::CALL,
+            safe_tx_gas: "0".to_string(),
+            base_gas: "0".to_string(),
+            gas_price: "0".to_string(),
+            gas_token: "0x0000000000000000000000000000000000000000".to_string(),
+            refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
+            contract_transaction_hash: send_erc20_request.transaction_hash.to_string(),
+            sender: send_erc20_request.sender.to_string(),
+            signature: send_erc20_request.signed_transaction_hash.to_string(),
         }
     }
 }

--- a/src/models/converters/transactions/send_eth_request.rs
+++ b/src/models/converters/transactions/send_eth_request.rs
@@ -1,7 +1,7 @@
 use crate::models::backend::multisig_transaction_request::MultisigTransactionRequest;
 use crate::models::commons::Operation;
 use crate::models::service::transactions::requests::{
-    SendErc20Request, SendEthRequest, SendFundsRequest,
+    SendErc20Request, SendErc721Request, SendEthRequest, SendFundsRequest,
 };
 
 impl SendFundsRequest {
@@ -10,6 +10,9 @@ impl SendFundsRequest {
             SendFundsRequest::Ether(send_ether_request) => Self::send_ether(send_ether_request),
             SendFundsRequest::Erc20(send_erc20_request) => {
                 Self::send_erc20_request(send_erc20_request)
+            }
+            SendFundsRequest::Erc721(send_erc721_request) => {
+                Self::send_erc721_request(send_erc721_request)
             }
         }
     }
@@ -46,6 +49,24 @@ impl SendFundsRequest {
             contract_transaction_hash: send_erc20_request.transaction_hash.to_string(),
             sender: send_erc20_request.sender.to_string(),
             signature: send_erc20_request.signed_transaction_hash.to_string(),
+        }
+    }
+
+    fn send_erc721_request(send_erc721_request: &SendErc721Request) -> MultisigTransactionRequest {
+        MultisigTransactionRequest {
+            to: send_erc721_request.receiver.to_string(),
+            value: "0".to_string(),
+            data: send_erc721_request.data.to_string(),
+            nonce: send_erc721_request.nonce.to_string(),
+            operation: Operation::CALL,
+            safe_tx_gas: "0".to_string(),
+            base_gas: "0".to_string(),
+            gas_price: "0".to_string(),
+            gas_token: "0x0000000000000000000000000000000000000000".to_string(),
+            refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
+            contract_transaction_hash: send_erc721_request.transaction_hash.to_string(),
+            sender: send_erc721_request.sender.to_string(),
+            signature: send_erc721_request.signed_transaction_hash.to_string(),
         }
     }
 }

--- a/src/models/converters/transactions/send_eth_request.rs
+++ b/src/models/converters/transactions/send_eth_request.rs
@@ -1,0 +1,23 @@
+use crate::models::backend::multisig_transaction_request::MultisigTransactionRequest;
+use crate::models::commons::Operation;
+use crate::models::service::transactions::requests::SendEthRequest;
+
+impl SendEthRequest {
+    pub fn to_multisig_transaction_request(&self) -> MultisigTransactionRequest {
+        MultisigTransactionRequest {
+            to: self.receiver.to_string(),
+            value: self.value.to_string(),
+            data: self.data.to_string(),
+            nonce: self.nonce.to_string(),
+            operation: Operation::CALL,
+            safe_tx_gas: "0".to_string(),
+            base_gas: "0".to_string(),
+            gas_price: "0".to_string(),
+            gas_token: "0x0000000000000000000000000000000000000000".to_string(),
+            refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
+            contract_transaction_hash: self.transaction_hash.to_string(),
+            sender: self.sender.to_string(),
+            signature: self.signed_transaction_hash.to_string(),
+        }
+    }
+}

--- a/src/models/service/transactions/requests.rs
+++ b/src/models/service/transactions/requests.rs
@@ -6,12 +6,29 @@ pub struct ConfirmationRequest {
     pub signed_safe_tx_hash: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "type")]
+pub enum SendFundsRequest {
+    Ether(SendEthRequest),
+    Erc20(SendErc20Request),
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SendEthRequest {
     pub receiver: String,
     pub sender: String,
     pub value: String,
+    pub transaction_hash: String,
+    pub signed_transaction_hash: String,
+    pub nonce: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SendErc20Request {
+    pub receiver: String,
+    pub sender: String,
     pub data: String,
     pub transaction_hash: String,
     pub signed_transaction_hash: String,

--- a/src/models/service/transactions/requests.rs
+++ b/src/models/service/transactions/requests.rs
@@ -11,6 +11,7 @@ pub struct ConfirmationRequest {
 pub enum SendFundsRequest {
     Ether(SendEthRequest),
     Erc20(SendErc20Request),
+    Erc721(SendErc721Request),
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -27,6 +28,17 @@ pub struct SendEthRequest {
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SendErc20Request {
+    pub receiver: String,
+    pub sender: String,
+    pub data: String,
+    pub transaction_hash: String,
+    pub signed_transaction_hash: String,
+    pub nonce: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SendErc721Request {
     pub receiver: String,
     pub sender: String,
     pub data: String,

--- a/src/models/service/transactions/requests.rs
+++ b/src/models/service/transactions/requests.rs
@@ -5,3 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct ConfirmationRequest {
     pub signed_safe_tx_hash: String,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendEthRequest {
+    pub receiver: String,
+    pub sender: String,
+    pub value: String,
+    pub data: String,
+    pub transaction_hash: String,
+    pub signed_transaction_hash: String,
+    pub nonce: String,
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -25,6 +25,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::history_transactions,
         transactions::queued_transactions,
         transactions::submit_confirmation,
+        transactions::send_eth,
         hooks::update,
         health::health
     ]

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -1,8 +1,9 @@
 use crate::config::request_cache_duration;
-use crate::models::service::transactions::requests::ConfirmationRequest;
+use crate::models::service::transactions::requests::{ConfirmationRequest, SendEthRequest};
 use crate::services::tx_confirmation;
 use crate::services::{
-    transactions_details, transactions_history, transactions_list, transactions_queued,
+    transactions_details, transactions_history, transactions_list, transactions_proposal,
+    transactions_queued,
 };
 use crate::utils::cache::CacheExt;
 use crate::utils::context::Context;
@@ -93,4 +94,16 @@ pub fn queued_transactions(
                 &trusted,
             )
         })
+}
+
+#[post(
+    "/v1/transactions/<safe_address>/eth_transfers",
+    data = "<send_eth_request>"
+)]
+pub fn send_eth(
+    context: Context,
+    safe_address: String,
+    send_eth_request: Json<SendEthRequest>,
+) -> ApiResult<()> {
+    transactions_proposal::send_eth(&context, &safe_address, &send_eth_request)
 }

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -97,13 +97,13 @@ pub fn queued_transactions(
 }
 
 #[post(
-    "/v1/transactions/<safe_address>/eth_transfers",
-    data = "<send_eth_request>"
+    "/v1/transactions/<safe_address>/transfers",
+    data = "<send_funds_request>"
 )]
 pub fn send_eth(
     context: Context,
     safe_address: String,
-    send_eth_request: Json<SendFundsRequest>,
+    send_funds_request: Json<SendFundsRequest>,
 ) -> ApiResult<()> {
-    transactions_proposal::send_funds(&context, &safe_address, &send_eth_request)
+    transactions_proposal::send_funds(&context, &safe_address, &send_funds_request)
 }

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -1,5 +1,5 @@
 use crate::config::request_cache_duration;
-use crate::models::service::transactions::requests::{ConfirmationRequest, SendEthRequest};
+use crate::models::service::transactions::requests::{ConfirmationRequest, SendFundsRequest};
 use crate::services::tx_confirmation;
 use crate::services::{
     transactions_details, transactions_history, transactions_list, transactions_proposal,
@@ -103,7 +103,7 @@ pub fn queued_transactions(
 pub fn send_eth(
     context: Context,
     safe_address: String,
-    send_eth_request: Json<SendEthRequest>,
+    send_eth_request: Json<SendFundsRequest>,
 ) -> ApiResult<()> {
-    transactions_proposal::send_eth(&context, &safe_address, &send_eth_request)
+    transactions_proposal::send_funds(&context, &safe_address, &send_eth_request)
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod hooks;
 pub mod transactions_details;
 pub mod transactions_history;
 pub mod transactions_list;
+pub mod transactions_proposal;
 pub mod transactions_queued;
 pub mod tx_confirmation;
 

--- a/src/services/transactions_proposal.rs
+++ b/src/services/transactions_proposal.rs
@@ -1,12 +1,12 @@
 use crate::config::base_transaction_service_url;
-use crate::models::service::transactions::requests::SendEthRequest;
+use crate::models::service::transactions::requests::SendFundsRequest;
 use crate::utils::context::Context;
 use crate::utils::errors::{ApiError, ApiResult};
 
-pub fn send_eth(
+pub fn send_funds(
     context: &Context,
     safe_address: &str,
-    send_eth_request: &SendEthRequest,
+    send_eth_request: &SendFundsRequest,
 ) -> ApiResult<()> {
     let url = format!(
         "{}/v1/safes/{}/transactions/",

--- a/src/services/transactions_proposal.rs
+++ b/src/services/transactions_proposal.rs
@@ -1,0 +1,32 @@
+use crate::config::base_transaction_service_url;
+use crate::models::service::transactions::requests::SendEthRequest;
+use crate::utils::context::Context;
+use crate::utils::errors::{ApiError, ApiResult};
+
+pub fn send_eth(
+    context: &Context,
+    safe_address: &str,
+    send_eth_request: &SendEthRequest,
+) -> ApiResult<()> {
+    let url = format!(
+        "{}/v1/safes/{}/transactions/",
+        base_transaction_service_url(),
+        &safe_address
+    );
+    let core_service_request = send_eth_request.to_multisig_transaction_request();
+
+    let response = context
+        .client()
+        .post(&url)
+        .json(&core_service_request)
+        .send()?;
+
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(ApiError::from_http_response(
+            response,
+            String::from("Unexpected tx confirmation error"),
+        ))
+    }
+}

--- a/src/services/transactions_proposal.rs
+++ b/src/services/transactions_proposal.rs
@@ -6,14 +6,14 @@ use crate::utils::errors::{ApiError, ApiResult};
 pub fn send_funds(
     context: &Context,
     safe_address: &str,
-    send_eth_request: &SendFundsRequest,
+    send_funds_request: &SendFundsRequest,
 ) -> ApiResult<()> {
     let url = format!(
         "{}/v1/safes/{}/transactions/",
         base_transaction_service_url(),
         &safe_address
     );
-    let core_service_request = send_eth_request.to_multisig_transaction_request();
+    let core_service_request = send_funds_request.to_multisig_transaction_request();
 
     let response = context
         .client()


### PR DESCRIPTION
DRAFT

We can probably merge the variants for `Erc20` and `Erc721` for the body of the `transfers` endpoint

Note 1: To try it out with the Android app, use this branch: https://github.com/gnosis/safe-android/tree/tx_sender
Note 2: You have to setup up an owner private key with an owner address to see the UI elements in android (Button in coins fragment and in collectible details)
Note 3: I will try to iron out as many of the issues I can in Android
Note 4: The transaction list fragment, doesn't easily show the newly proposed transactions. There is a bug with a looping refreshing state in both transaction list fragments (queued and history)

- [x] Defined polymorphic minimal structure for posting 
- [x] `MultisigTransactionRequest` is defined in a way that gas related fields and refund receivers are set to `0` or `0x0`
- [ ] Unit tests (if we decide to merge this) 
- [ ] Define a return value for the endpoint (maybe?)