### PR TITLE
Remove usd naming from core services

### DIFF
--- a/src/json/balances/balance_compound_ether.json
+++ b/src/json/balances/balance_compound_ether.json
@@ -7,8 +7,6 @@
     "logoUri": "https://gnosis-safe-token-logos.s3.amazonaws.com/0xd6801a1DfFCd0a410336Ef88DeF4320D6DF1883e.png"
   },
   "balance": "5002",
-  "balanceUsd": "0.0014",
-  "usdConversion": "28.5462",
   "fiatBalance": "0.0014",
   "fiatConversion": "28.5462",
   "fiatCode": "USD"

--- a/src/json/balances/balance_ether.json
+++ b/src/json/balances/balance_ether.json
@@ -2,8 +2,6 @@
   "tokenAddress": null,
   "token": null,
   "balance": "7457594371050000001",
-  "balanceUsd": "2523.7991",
-  "usdConversion": "338.42",
   "fiatBalance": "2523.7991",
   "fiatConversion": "338.42",
   "fiatCode": "USD"


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x ] You are using the nightly version of rust `rustup default nighly`
- [x ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x ] You ran `cargo fmt` on the code base before submitting
