### PR TITLE
Added error logging

### DIFF
--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -92,7 +92,14 @@ impl fmt::Display for ApiError {
 }
 
 impl<'r> Responder<'r> for ApiError {
-    fn respond_to(self, _: &Request) -> response::Result<'r> {
+    fn respond_to(self, request: &Request) -> response::Result<'r> {
+        log::error!(
+            "ERR::{}::{}::{}",
+            self.status,
+            request.uri().to_string(),
+            self.details
+        );
+
         Response::build()
             .sized_body(Cursor::new(
                 serde_json::to_string(&self.details).expect("Couldn't serialize error"),


### PR DESCRIPTION
Closes #197 

Changes:
- `Responder` impl for `ApiError` logs the error too. Example output:
`[2021-02-09T13:23:21Z ERROR safe_client_gateway::utils::errors] ERR::500::/about::ApiErrorMessage: code:1337; message:Some("Error(\"missing field `transactionServiceBaseUrl`\", line: 1, column: 29)"); arguments:None`

- To disable rocket logs we should set `.env::ROCKET_LOG = off` 
