### PR TITLE
Warm up cache with TokenInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cargo-watch"
 version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,16 +283,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
-dependencies = [
- "cfg-if 0.1.10",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -729,11 +725,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -795,11 +791,11 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "http",
 ]
 
@@ -839,17 +835,17 @@ dependencies = [
  "time",
  "traitobject",
  "typeable",
- "unicase 1.4.2",
+ "unicase",
  "url 1.7.2",
 ]
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -869,15 +865,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.5.6",
- "hyper 0.13.9",
+ "bytes 1.0.1",
+ "hyper 0.14.4",
  "native-tls",
  "tokio",
- "tokio-tls",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1096,16 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
-]
-
-[[package]]
 name = "mio"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,10 +1104,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.11",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log 0.4.11",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1132,7 +1131,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log 0.4.11",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -1146,6 +1145,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1235,9 +1244,18 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1445,12 +1463,6 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.54",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
@@ -1686,37 +1698,35 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.9",
+ "hyper 0.14.4",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static 1.4.0",
  "log 0.4.11",
  "mime 0.3.16",
- "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tls",
+ "tokio-native-tls",
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-bindgen-test",
  "web-sys",
  "winreg",
 ]
@@ -1874,12 +1884,6 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot 0.11.1",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2217,20 +2221,17 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static 1.4.0",
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
  "memchr",
- "mio",
+ "mio 0.7.7",
  "num_cpus",
- "pin-project-lite 0.1.11",
- "slab",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2266,6 +2267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,7 +2286,7 @@ dependencies = [
  "futures",
  "lazy_static 1.4.0",
  "log 0.4.11",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab",
@@ -2303,32 +2314,22 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log 0.4.11",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2354,8 +2355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.11",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "tracing-core",
 ]
 
@@ -2415,15 +2415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 dependencies = [
  "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2634,30 +2625,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
-dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
-]
 
 [[package]]
 name = "watchexec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dotenv_codegen = "0.15.0"
 
 rocket = "0.4.5"
 rocket_codegen = "0.4.5"
-reqwest = { version = "0.10.6", features = ["blocking", "json"] }
+reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 
 # Ethereum types does not support checksummed addresses
 # ethereum-types= { version = "0.8.0", features = ["serialize"]}

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -184,9 +184,12 @@ impl DefaultInfoProvider<'_> {
 
     fn load_safe_info(&mut self, safe: &String) -> ApiResult<Option<SafeInfo>> {
         let url = format!("{}/v1/safes/{}/", base_transaction_service_url(), safe);
-        let data: String = self
-            .cache
-            .request_cached(self.client, &url, info_cache_duration())?;
+        let data: String = self.cache.request_cached(
+            self.client,
+            &url,
+            info_cache_duration(),
+            info_cache_duration(),
+        )?;
         Ok(serde_json::from_str(&data).unwrap_or(None))
     }
 
@@ -217,7 +220,7 @@ impl DefaultInfoProvider<'_> {
             if result.is_ok() {
                 info_cache_duration()
             } else {
-                10000
+                info_error_cache_timeout()
             },
         );
         result
@@ -253,9 +256,12 @@ impl DefaultInfoProvider<'_> {
 
     fn fetch_exchange(&self) -> ApiResult<Exchange> {
         let url = format!("https://api.exchangeratesapi.io/latest?base=USD");
-        let body = self
-            .cache
-            .request_cached(self.client, &url, exchange_api_cache_duration())?;
+        let body = self.cache.request_cached(
+            self.client,
+            &url,
+            exchange_api_cache_duration(),
+            info_cache_duration(),
+        )?;
         Ok(serde_json::from_str::<Exchange>(&body)?)
     }
 }

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -240,7 +240,7 @@ impl DefaultInfoProvider<'_> {
                 .get(&currency_code)
                 .cloned()
                 .ok_or(api_error!("Currency not found")),
-            None => Err(bail!("Currency not found")),
+            None => Err(api_error!("Currency not found")),
         }
     }
 

--- a/src/services/hooks.rs
+++ b/src/services/hooks.rs
@@ -3,16 +3,16 @@ use crate::utils::cache::Cache;
 use crate::utils::errors::ApiResult;
 
 pub fn invalidate_caches(cache: &impl Cache, payload: &Payload) -> ApiResult<()> {
-    cache.invalidate_pattern(&format!("*{}*", &payload.address));
+    cache.invalidate_caches(&payload.address);
     payload.details.as_ref().map(|d| match d {
         PayloadDetails::NewConfirmation(data) => {
-            cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            cache.invalidate_caches(&data.safe_tx_hash);
         }
         PayloadDetails::ExecutedMultisigTransaction(data) => {
-            cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            cache.invalidate_caches(&data.safe_tx_hash);
         }
         PayloadDetails::PendingMultisigTransaction(data) => {
-            cache.invalidate_pattern(&format!("*{}*", data.safe_tx_hash));
+            cache.invalidate_caches(&data.safe_tx_hash);
         }
         _ => {}
     });

--- a/src/services/hooks.rs
+++ b/src/services/hooks.rs
@@ -1,5 +1,5 @@
 use crate::models::backend::webhooks::{Payload, PayloadDetails};
-use crate::utils::cache::Cache;
+use crate::utils::cache::{Cache, CacheExt};
 use crate::utils::errors::ApiResult;
 
 pub fn invalidate_caches(cache: &impl Cache, payload: &Payload) -> ApiResult<()> {

--- a/src/services/tests/invalidate_caches.rs
+++ b/src/services/tests/invalidate_caches.rs
@@ -15,14 +15,24 @@ fn invalidate_with_empty_payload() {
     };
 
     let mut mock_cache = MockCache::new();
+    let mut sequence = Sequence::new();
+
     mock_cache.expect_fetch().times(0);
     mock_cache.expect_create().times(0);
     mock_cache.expect_invalidate().times(0);
+
     mock_cache
         .expect_invalidate_pattern()
-        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .times(1)
         .return_const(())
-        .times(1);
+        .with(eq("c_resp_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq("c_reqs_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .in_sequence(&mut sequence);
 
     invalidate_caches(&mock_cache, &payload).unwrap();
 }
@@ -47,14 +57,28 @@ fn invalidate_new_confirmation_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .with(eq("c_resp_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq("c_reqs_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
         .with(eq(
-            "*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+            "c_resp_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+        ))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq(
+            "c_reqs_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
         ))
         .in_sequence(&mut sequence);
 
@@ -84,14 +108,28 @@ fn invalidate_executed_multisig_transaction_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .with(eq("c_resp_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq("c_reqs_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
         .with(eq(
-            "*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+            "c_resp_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+        ))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq(
+            "c_reqs_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
         ))
         .in_sequence(&mut sequence);
 
@@ -119,14 +157,28 @@ fn invalidate_pending_multisig_transaction_payload() {
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
-        .with(eq("*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .with(eq("c_resp_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq("c_reqs_*0x1230B3d59858296A31053C1b8562Ecf89A2f888b*"))
         .in_sequence(&mut sequence);
     mock_cache
         .expect_invalidate_pattern()
         .times(1)
         .return_const(())
         .with(eq(
-            "*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+            "c_resp_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
+        ))
+        .in_sequence(&mut sequence);
+    mock_cache
+        .expect_invalidate_pattern()
+        .times(1)
+        .return_const(())
+        .with(eq(
+            "c_reqs_*0x65df8a1e5a40703d9c67d5df6f9b552d3830faf0507c3d7350ba3764d3a68621*",
         ))
         .in_sequence(&mut sequence);
 

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -5,6 +5,9 @@ use rocket_contrib::databases::redis::{self, pipe, Commands, Iter, PipelineComma
 use serde::ser::Serialize;
 use serde_json;
 
+pub const CACHE_RESP_PREFIX: &'static str = "c_resp";
+pub const CACHE_REQS_PREFIX: &'static str = "c_reqs";
+
 #[database("service_cache")]
 pub struct ServiceCache(redis::Connection);
 
@@ -39,8 +42,8 @@ impl Cache for ServiceCache {
 
 pub trait CacheExt: Cache {
     fn invalidate_caches(&self, key: &str) {
-        self.invalidate_pattern(&format!("c_resp_*{}*", &key));
-        self.invalidate_pattern(&format!("c_reqs_*{}*", &key));
+        self.invalidate_pattern(&format!("{}_*{}*", CACHE_RESP_PREFIX, &key));
+        self.invalidate_pattern(&format!("{}_*{}*", CACHE_REQS_PREFIX, &key));
     }
 
     fn cache_resp<R>(


### PR DESCRIPTION
This PR just shows what changes are required to load all tokens at once into the cache. This will allow us to run some tests on the performace impact.

Findings:
- Lots of small requests to core services result in quite some overhead right now
  - Keep Alive does not solve this
  - Http2 is not available for services right now (we are coordinating with devops to evaluate this)
- Request for unknown addresses that don't hit a known token take longer
  - Information is pulled from on-chain (@Uxio0 maybe we could add a query param, that disables the on-chain lookup?)
- Using `/v1/tokens/?limit=10000` to load all tokens into cache provides improvements
  - Cold load request time goes down by 50% (~15s to ~8s) - Note: I did NOT do extensive benchmarking 
  - Uses ~1.5mb of redis cache (not really an issue) - We should probably check our [REDIS eviction policy](https://redis.io/topics/lru-cache)
  - If we want to do the same for contract info, we should filter to `​/contracts​/` to filter out contract without a display name

Future ideas:
- Predict what caches to warm/ pre-populate caches
  - Keep stats on what Safes interact with the gateway and have task that keps the results for these in cache up to date (e.g. when we get a webhook to invalidate them we would also reload them directly, so that they are up to date)
  - Create a cron-job that updates the caches (e.g. for tokens, for contracts, for safe apps, for most used safes)
    - Related: Add cache admin endpoint
-  Error cache duration: https://github.com/gnosis/safe-client-gateway/issues/246

Changes to caching:
- Use cache prefixes to cleary separate cache entries for tokens from other cache entries (also to avoid that they get invalidated by webhooks)
- load all tokens into cache instead of 1 by 1

Unrelated changes:
- Update pre-commit hook to not format child files