### PR TITLE
Removed to field from ethereum transactions

### DIFF
--- a/src/models/backend/transactions.rs
+++ b/src/models/backend/transactions.rs
@@ -54,7 +54,6 @@ pub struct MultisigTransaction {
 #[serde(rename_all = "camelCase")]
 pub struct EthereumTransaction {
     pub execution_date: DateTime<Utc>,
-    pub to: String,
     pub data: Option<String>,
     pub tx_hash: String,
     pub block_number: u64,

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -98,7 +98,6 @@ fn ethereum_tx_to_summary_transaction_no_transfers() {
 
     let ethereum_tx = EthereumTransaction {
         execution_date: Utc::now(),
-        to: String::from("0x1234"),
         data: None,
         tx_hash: String::from("0x4321"),
         block_number: 0,
@@ -145,7 +144,6 @@ fn ethereum_tx_to_summary_transaction_with_transfers() {
     ];
     let ethereum_tx = EthereumTransaction {
         execution_date: timestamp,
-        to: String::from("0x1234"),
         data: None,
         tx_hash: String::from("0x4321"),
         block_number: 0,


### PR DESCRIPTION
Closes #271 

Changes:
- Removed `to` as expected field from Ethereum transactions as it's not used.