### PR TITLE
Rejection list for transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,7 @@ dependencies = [
  "env_logger",
  "ethabi 12.0.0",
  "ethcontract-common",
+ "ethereum-types 0.9.2",
  "itertools",
  "log 0.4.11",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -42,7 +42,7 @@ checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 dependencies = [
  "block-cipher-trait",
  "byteorder",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 dependencies = [
  "block-cipher-trait",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -72,6 +72,18 @@ checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"
@@ -125,15 +137,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -142,7 +174,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -153,6 +185,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -168,6 +206,12 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byte-tools"
@@ -296,7 +340,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "percent-encoding 2.1.0",
- "rand",
+ "rand 0.7.3",
  "sha2",
  "time",
 ]
@@ -329,12 +373,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
 ]
 
@@ -410,6 +460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
 name = "devise"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,7 +514,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -520,6 +590,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+dependencies = [
+ "ethereum-types 0.9.2",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tiny-keccak 1.5.0",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "ethabi"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d4e679d6864bc26210feb5cf044e245741cd9d7701b35c00440a6e84d61399"
+dependencies = [
+ "anyhow",
+ "ethereum-types 0.10.0",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "uint 0.9.0",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.6.1",
+ "impl-rlp 0.2.1",
+ "impl-serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a621dcebea74f2a6f2002d0a885c81ccf6cbdf86760183316a7722b5707ca4"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethcontract-common"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20addff5b356ce614996ceb5c217bc4d95f50f21bbddca32e91579978f0ef316"
+dependencies = [
+ "ethabi 13.0.0",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak 2.0.2",
+ "web3",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+dependencies = [
+ "ethbloom 0.9.2",
+ "fixed-hash 0.6.1",
+ "impl-rlp 0.2.1",
+ "impl-serde",
+ "primitive-types 0.7.3",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05dc5f0df4915fa6dff7f975a8366ecfaaa8959c74235469495153e7bb1b280e"
+dependencies = [
+ "ethbloom 0.10.0",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "primitive-types 0.8.0",
+ "uint 0.9.0",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +705,30 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
+dependencies = [
+ "byteorder",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.3",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -625,12 +819,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -640,10 +850,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
 
 [[package]]
 name = "futures-sink"
@@ -661,17 +894,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project 1.0.2",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -685,6 +929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +947,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -759,12 +1024,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "hkdf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
 dependencies = [
- "digest",
+ "digest 0.8.1",
  "hmac",
 ]
 
@@ -775,7 +1046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -905,6 +1176,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+dependencies = [
+ "rlp 0.4.6",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp 0.5.0",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1290,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a47c4c3ac843f9a4238943f97620619033dadef4b378cd1e8addd170de396b3"
+dependencies = [
+ "futures 0.3.8",
+ "log 0.4.11",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,9 +1344,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "lock_api"
@@ -1112,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log 0.4.11",
@@ -1307,6 +1633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1669,18 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1528,10 +1872,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
+dependencies = [
+ "fixed-hash 0.6.1",
+ "impl-codec",
+ "impl-rlp 0.2.1",
+ "impl-serde",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3824ae2c5e27160113b9e029a10ec9e3f0237bad8029f69c7724393c9fdefd8"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "uint 0.9.0",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1597,16 +1973,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1616,7 +2009,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1625,7 +2028,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1634,7 +2046,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1645,7 +2057,7 @@ checksum = "f0c747d743d48233f9bc3ed3fb00cb84c1d98d8c7f54ed2d4cca9adf461a7ef3"
 dependencies = [
  "bytes 0.4.12",
  "combine",
- "futures",
+ "futures 0.1.30",
  "sha1",
  "tokio-codec",
  "tokio-executor",
@@ -1698,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -1729,6 +2141,25 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rlp"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+dependencies = [
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
+dependencies = [
+ "bytes 1.0.1",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -1814,6 +2245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2275,8 @@ dependencies = [
  "dotenv",
  "dotenv_codegen",
  "env_logger",
+ "ethabi 12.0.0",
+ "ethcontract-common",
  "itertools",
  "log 0.4.11",
  "mockall",
@@ -1995,10 +2434,22 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2039,6 +2490,12 @@ name = "state"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stderrlog"
@@ -2107,7 +2564,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2205,6 +2662,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,7 +2704,7 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.7",
+ "mio 0.7.9",
  "num_cpus",
  "pin-project-lite",
 ]
@@ -2241,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.30",
  "tokio-io",
 ]
 
@@ -2252,7 +2727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils",
- "futures",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -2262,7 +2737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.30",
  "log 0.4.11",
 ]
 
@@ -2283,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils",
- "futures",
+ "futures 0.1.30",
  "lazy_static 1.4.0",
  "log 0.4.11",
  "mio 0.6.23",
@@ -2302,7 +2777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -2312,7 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.30",
  "iovec",
  "mio 0.6.23",
  "tokio-io",
@@ -2409,6 +2884,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "uint"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,7 +2958,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 2.3.0",
 ]
 
@@ -2653,6 +3152,29 @@ checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4080a844bbb41437f0d432138f0a7543780a40b43345b76dc0338c59bdfd1336"
+dependencies = [
+ "arrayvec",
+ "derive_more",
+ "ethabi 13.0.0",
+ "ethereum-types 0.10.0",
+ "futures 0.3.8",
+ "futures-timer",
+ "hex",
+ "jsonrpc-core",
+ "log 0.4.11",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.2",
+ "rlp 0.5.0",
+ "serde",
+ "serde_json",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 
 # Ethereum types does not support checksummed addresses
 # ethereum-types= { version = "0.8.0", features = ["serialize"]}
+ethcontract-common = "0.11.1"
+ethabi = "12.0.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ rocket = "0.4.5"
 rocket_codegen = "0.4.5"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 
-# Ethereum types does not support checksummed addresses
-# ethereum-types= { version = "0.8.0", features = ["serialize"]}
 ethcontract-common = "0.11.1"
 ethereum-types = { version = "0.9.2", features = ["serialize"]}
 ethabi = "12.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 # Ethereum types does not support checksummed addresses
 # ethereum-types= { version = "0.8.0", features = ["serialize"]}
 ethcontract-common = "0.11.1"
+ethereum-types = { version = "0.9.2", features = ["serialize"]}
 ethabi = "12.0.0"
 
 serde = { version = "1.0", features = ["derive"] }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,3 +46,13 @@ macro_rules! api_error {
         $crate::private::new_adhoc()
     };
 }
+
+macro_rules! to_hex_string {
+    ($input:expr) => {{
+        let mut output = String::new();
+        for byte in $input.iter() {
+            output.push_str(&format!("{:02x?}", byte)) // uppercase x is for uppercase hex char.
+        }
+        format!("0x{}", output)
+    }};
+}

--- a/src/models/converters/transactions/details.rs
+++ b/src/models/converters/transactions/details.rs
@@ -14,6 +14,7 @@ use crate::utils::errors::ApiResult;
 impl MultisigTransaction {
     pub fn to_transaction_details(
         &self,
+        rejections: Option<Vec<MultisigConfirmation>>,
         info_provider: &mut dyn InfoProvider,
     ) -> ApiResult<TransactionDetails> {
         let safe_info = info_provider.safe_info(&self.safe.to_string())?;
@@ -36,7 +37,7 @@ impl MultisigTransaction {
             }),
             tx_hash: self.transaction_hash.as_ref().map(|hash| hash.to_owned()),
             detailed_execution_info: Some(DetailedExecutionInfo::Multisig(
-                self.build_execution_details(safe_info, gas_token),
+                self.build_execution_details(safe_info, gas_token, rejections),
             )),
             safe_app_info: self
                 .origin
@@ -49,6 +50,7 @@ impl MultisigTransaction {
         &self,
         safe_info: SafeInfo,
         gas_token_info: Option<TokenInfo>,
+        rejections: Option<Vec<MultisigConfirmation>>,
     ) -> MultisigExecutionDetails {
         MultisigExecutionDetails {
             submitted_at: self.submission_date.timestamp_millis(),
@@ -85,7 +87,8 @@ impl MultisigTransaction {
                 .as_ref()
                 .unwrap_or(&String::from("0"))
                 .to_owned(),
-            gas_token_info: gas_token_info,
+            gas_token_info,
+            rejections,
         }
     }
 }

--- a/src/models/converters/transactions/details.rs
+++ b/src/models/converters/transactions/details.rs
@@ -14,7 +14,7 @@ use crate::utils::errors::ApiResult;
 impl MultisigTransaction {
     pub fn to_transaction_details(
         &self,
-        conflicting_txs: Vec<MultisigTransaction>,
+        rejections: Option<Vec<String>>,
         info_provider: &mut dyn InfoProvider,
     ) -> ApiResult<TransactionDetails> {
         let safe_info = info_provider.safe_info(&self.safe.to_string())?;
@@ -37,7 +37,7 @@ impl MultisigTransaction {
             }),
             tx_hash: self.transaction_hash.as_ref().map(|hash| hash.to_owned()),
             detailed_execution_info: Some(DetailedExecutionInfo::Multisig(
-                self.build_execution_details(safe_info, gas_token, conflicting_txs),
+                self.build_execution_details(safe_info, gas_token, rejections),
             )),
             safe_app_info: self
                 .origin
@@ -50,7 +50,7 @@ impl MultisigTransaction {
         &self,
         safe_info: SafeInfo,
         gas_token_info: Option<TokenInfo>,
-        conflicting_txs: Vec<MultisigTransaction>,
+        rejections: Option<Vec<String>>,
     ) -> MultisigExecutionDetails {
         MultisigExecutionDetails {
             submitted_at: self.submission_date.timestamp_millis(),
@@ -88,32 +88,7 @@ impl MultisigTransaction {
                 .unwrap_or(&String::from("0"))
                 .to_owned(),
             gas_token_info,
-            rejections: self.get_rejections(conflicting_txs),
-        }
-    }
-
-    fn get_rejections(
-        &self,
-        conflicting_txs: Vec<MultisigTransaction>,
-    ) -> Option<Vec<MultisigConfirmation>> {
-        if self.is_cancellation() {
-            None
-        } else {
-            conflicting_txs
-                .iter()
-                .find(|tx| tx.is_cancellation())
-                .map(|tx| {
-                    tx.confirmations.as_ref().map(|it| {
-                        it.iter()
-                            .map(|confirmation| MultisigConfirmation {
-                                signer: confirmation.owner.to_owned(),
-                                signature: confirmation.signature.to_owned(),
-                                submitted_at: confirmation.submission_date.timestamp_millis(),
-                            })
-                            .collect()
-                    })
-                })
-                .flatten()
+            rejections,
         }
     }
 }

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -213,7 +213,7 @@ impl MultisigTransaction {
             .unwrap_or(0)
     }
 
-    pub(crate) fn is_cancellation(&self) -> bool {
+    fn is_cancellation(&self) -> bool {
         self.to == self.safe
             && data_size(&self.data) == 0
             && self.value.as_ref().map_or(true, |value| value == "0")

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -213,7 +213,7 @@ impl MultisigTransaction {
             .unwrap_or(0)
     }
 
-    fn is_cancellation(&self) -> bool {
+    pub(crate) fn is_cancellation(&self) -> bool {
         self.to == self.safe
             && data_size(&self.data) == 0
             && self.value.as_ref().map_or(true, |value| value == "0")

--- a/src/models/converters/transactions/tests/details.rs
+++ b/src/models/converters/transactions/tests/details.rs
@@ -103,12 +103,14 @@ fn multisig_custom_transaction_to_transaction_details() {
                         submitted_at: timestamp_confirmation1,
                     },
                 ],
+                rejections: None,
                 gas_token_info: None
             })),
         safe_app_info: None
     };
 
-    let actual = MultisigTransaction::to_transaction_details(&multisig_tx, &mut mock_info_provider);
+    let actual =
+        MultisigTransaction::to_transaction_details(&multisig_tx, None, &mut mock_info_provider);
 
     assert_eq!(expected, actual.unwrap());
 }
@@ -354,6 +356,7 @@ fn multisig_transaction_with_origin() {
                          submitted_at: 1607346715000,
                      }
                 ],
+                rejections: None,
                 gas_token_info: None,
             })),
         safe_app_info: Some(SafeAppInfo {
@@ -364,7 +367,8 @@ fn multisig_transaction_with_origin() {
         tx_hash: Some("0x4d84602bf94d099159baa41993edca288abb5f9795dd51cc14bd66195b9fdc77".to_string()),
     };
 
-    let actual = MultisigTransaction::to_transaction_details(&multisig_tx, &mut mock_info_provider);
+    let actual =
+        MultisigTransaction::to_transaction_details(&multisig_tx, None, &mut mock_info_provider);
 
     assert_eq!(expected, actual.unwrap());
 }

--- a/src/models/service/transactions/details.rs
+++ b/src/models/service/transactions/details.rs
@@ -39,7 +39,7 @@ pub struct MultisigExecutionDetails {
     pub confirmations_required: u64,
     pub confirmations: Vec<MultisigConfirmation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub rejections: Option<Vec<MultisigConfirmation>>,
+    pub rejections: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_token_info: Option<TokenInfo>,
 }

--- a/src/models/service/transactions/details.rs
+++ b/src/models/service/transactions/details.rs
@@ -39,6 +39,8 @@ pub struct MultisigExecutionDetails {
     pub confirmations_required: u64,
     pub confirmations: Vec<MultisigConfirmation>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub rejections: Option<Vec<MultisigConfirmation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_token_info: Option<TokenInfo>,
 }
 

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -55,9 +55,12 @@ fn get_conflicting_txs(
     );
     debug!("{:#?}", &url);
 
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let backend_transactions: Page<MultisigTransaction> = serde_json::from_str(&body)?;
     Ok(backend_transactions.results)
 }

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -6,7 +6,7 @@ use crate::config::{
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::models::backend::transfers::Transfer;
 use crate::models::commons::Page;
-use crate::models::service::transactions::details::{MultisigConfirmation, TransactionDetails};
+use crate::models::service::transactions::details::TransactionDetails;
 use crate::models::service::transactions::{
     TransactionIdParts, ID_PREFIX_CREATION_TX, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX,
     ID_PREFIX_MULTISIG_TX, ID_SEPARATOR,
@@ -36,9 +36,9 @@ pub(super) fn get_multisig_transaction_details(
     )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
 
-    let rejections = get_rejections(&context, &multisig_tx);
+    let conflicting_txs = get_rejections(&context, &multisig_tx).unwrap_or(vec![]);
 
-    let details = multisig_tx.to_transaction_details(rejections, &mut info_provider)?;
+    let details = multisig_tx.to_transaction_details(conflicting_txs, &mut info_provider)?;
 
     Ok(details)
 }
@@ -46,7 +46,7 @@ pub(super) fn get_multisig_transaction_details(
 fn get_rejections(
     context: &Context,
     multisig_tx: &MultisigTransaction,
-) -> Option<Vec<MultisigConfirmation>> {
+) -> ApiResult<Vec<MultisigTransaction>> {
     let url = format!(
         "{}/v1/safes/{}/multisig-transactions/?nonce={}",
         base_transaction_service_url(),
@@ -56,25 +56,9 @@ fn get_rejections(
 
     let body = context
         .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())
-        .ok()?;
-    let backend_transactions: Page<MultisigTransaction> = serde_json::from_str(&body).ok()?;
-    backend_transactions
-        .results
-        .iter()
-        .find(|tx| tx.is_cancellation())
-        .map(|tx| {
-            tx.confirmations.as_ref().map(|it| {
-                it.iter()
-                    .map(|confirmation| MultisigConfirmation {
-                        signer: confirmation.owner.to_owned(),
-                        signature: confirmation.signature.to_owned(),
-                        submitted_at: confirmation.submission_date.timestamp_millis(),
-                    })
-                    .collect()
-            })
-        })
-        .flatten()
+        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let backend_transactions: Page<MultisigTransaction> = serde_json::from_str(&body)?;
+    Ok(backend_transactions.results)
 }
 
 fn get_ethereum_transaction_details(

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -44,7 +44,7 @@ pub(super) fn get_multisig_transaction_details(
 }
 
 fn get_rejections(
-    context: &&Context,
+    context: &Context,
     multisig_tx: &MultisigTransaction,
 ) -> Option<Vec<MultisigConfirmation>> {
     let url = format!(

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -37,12 +37,7 @@ pub(super) fn get_multisig_transaction_details(
     )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
 
-    let rejections = fetch_rejections(
-        context,
-        &multisig_tx.safe,
-        &multisig_tx.to,
-        multisig_tx.nonce,
-    );
+    let rejections = fetch_rejections(context, &multisig_tx.safe, multisig_tx.nonce);
 
     let details = multisig_tx.to_transaction_details(rejections, &mut info_provider)?;
 

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -37,7 +37,12 @@ pub(super) fn get_multisig_transaction_details(
     )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
 
-    let rejections = fetch_rejections(context, &multisig_tx.safe, &multisig_tx.nonce);
+    let rejections = fetch_rejections(
+        context,
+        &multisig_tx.safe,
+        &multisig_tx.to,
+        multisig_tx.nonce,
+    );
 
     let details = multisig_tx.to_transaction_details(rejections, &mut info_provider)?;
 

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -36,14 +36,14 @@ pub(super) fn get_multisig_transaction_details(
     )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
 
-    let conflicting_txs = get_rejections(&context, &multisig_tx).unwrap_or(vec![]);
+    let conflicting_txs = get_conflicting_txs(&context, &multisig_tx).unwrap_or(vec![]);
 
     let details = multisig_tx.to_transaction_details(conflicting_txs, &mut info_provider)?;
 
     Ok(details)
 }
 
-fn get_rejections(
+fn get_conflicting_txs(
     context: &Context,
     multisig_tx: &MultisigTransaction,
 ) -> ApiResult<Vec<MultisigTransaction>> {
@@ -53,6 +53,7 @@ fn get_rejections(
         &multisig_tx.safe,
         &multisig_tx.nonce
     );
+    debug!("{:#?}", &url);
 
     let body = context
         .cache()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod context;
 pub mod cors;
 pub mod errors;
 pub mod json;
+pub mod transactions;
 
 #[cfg(test)]
 mod tests;

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -3,3 +3,4 @@ mod data_decoded_utils;
 mod errors;
 mod json;
 mod method_names;
+mod transactions;

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,4 +1,5 @@
-use crate::utils::transactions::{domain_hash, hash};
+use crate::utils::transactions::{cancellation_parts_hash, domain_hash, hash};
+use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
 
 #[test]
@@ -22,9 +23,32 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     .unwrap();
     let nonce = 39;
 
-    let actual = to_hex_string!(hash(&safe_address, nonce).to_vec());
+    let actual = to_hex_string!(hash(safe_address, nonce).to_vec());
     assert_eq!(
-        "0x931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b",
+        "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
         actual
+    );
+}
+
+#[test]
+fn parts_hash_for_cancellation() {
+    let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
+        "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
+    ))
+    .unwrap();
+    let nonce = 39;
+
+    let actual = cancellation_parts_hash(safe_address, nonce);
+    assert_eq!(
+        to_hex_string!(actual),
+        "0xf0c66ea90dae4d21f8fed03cb6e7f03eb0720479fb2562915921721eed809626"
+    );
+}
+
+#[test]
+fn empty_data_keccak() {
+    assert_eq!(
+        to_hex_string!(keccak256(vec![])),
+        "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
     );
 }

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -38,7 +38,7 @@ fn parts_hash_for_cancellation() {
     .unwrap();
     let nonce = 39;
 
-    let actual = cancellation_parts_hash(safe_address, nonce);
+    let actual = cancellation_parts_hash(&safe_address, nonce);
     assert_eq!(
         to_hex_string!(actual),
         "0xf0c66ea90dae4d21f8fed03cb6e7f03eb0720479fb2562915921721eed809626"

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,0 +1,30 @@
+use crate::utils::transactions::{domain_hash, hash, to_hex_string};
+use ethereum_types::Address;
+
+#[test]
+fn domain_hash_for_safe_address() {
+    let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
+        "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
+    ))
+    .unwrap();
+    let actual = to_hex_string(domain_hash(&safe_address).to_vec());
+    assert_eq!(
+        "6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
+        actual
+    );
+}
+
+#[test]
+fn safe_tx_hash_for_safe_address_cancellation_tx() {
+    let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
+        "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
+    ))
+    .unwrap();
+    let nonce = 39;
+
+    let actual = to_hex_string(hash(&safe_address, nonce).to_vec());
+    assert_eq!(
+        "931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b",
+        actual
+    );
+}

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,4 +1,4 @@
-use crate::utils::transactions::{domain_hash, hash, to_hex_string};
+use crate::utils::transactions::{domain_hash, hash};
 use ethereum_types::Address;
 
 #[test]
@@ -7,9 +7,9 @@ fn domain_hash_for_safe_address() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string(domain_hash(&safe_address).to_vec());
+    let actual = to_hex_string!(domain_hash(&safe_address).to_vec());
     assert_eq!(
-        "6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
+        "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
         actual
     );
 }
@@ -22,9 +22,9 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     .unwrap();
     let nonce = 39;
 
-    let actual = to_hex_string(hash(&safe_address, nonce).to_vec());
+    let actual = to_hex_string!(hash(&safe_address, nonce).to_vec());
     assert_eq!(
-        "931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b",
+        "0x931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b",
         actual
     );
 }

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -1,0 +1,11 @@
+use ethabi::{Address, Int};
+use ethcontract_common::hash::keccak256;
+
+fn build_cancellation_tx(safe_address: &str, nonce: &str) {
+    let safe_address: Address = serde_json::from_str(safe_address).unwrap();
+    let nonce: Int = serde_json::from_str(nonce).unwrap();
+    let hash = &ethabi::encode(&[
+        ethabi::Token::Address(safe_address),
+        ethabi::Token::Int(nonce),
+    ]);
+}

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -18,24 +18,18 @@ pub const SAFE_TX_TYPEHASH: &'static str =
 pub const ERC191_BYTE: &'static str = "19";
 pub const ERC191_VERSION: &'static str = "01";
 
-pub fn fetch_rejections(
-    context: &Context,
-    safe_address: &str,
-    to: &str,
-    nonce: u64,
-) -> Option<Vec<String>> {
+pub fn fetch_rejections(context: &Context, safe_address: &str, nonce: u64) -> Option<Vec<String>> {
     let safe_address: Address =
         serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
-    let to: Address =
-        serde_json::from_value(serde_json::value::Value::String(to.to_string())).unwrap();
-    let hash = hash(&safe_address, to, nonce);
+
+    let hash = hash(&safe_address, nonce);
     log::error!("0x{:#?}", to_hex_string(hash.into()));
 
     // correct safe_tx_hash 0x931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b
     None
 }
 
-fn hash(safe_address: &Address, to: Address, nonce: u64) -> [u8; 32] {
+pub(super) fn hash(safe_address: &Address, nonce: u64) -> [u8; 32] {
     let erc_191_byte = u8::from_str_radix(ERC191_BYTE, 16).unwrap();
     let erc_191_version = u8::from_str_radix(ERC191_VERSION, 16).unwrap();
     let type_hash: H256 =
@@ -71,7 +65,7 @@ fn hash(safe_address: &Address, to: Address, nonce: u64) -> [u8; 32] {
     return keccak256(hashable);
 }
 
-fn domain_hash(safe_address: &Address) -> [u8; 32] {
+pub(super) fn domain_hash(safe_address: &Address) -> [u8; 32] {
     let domain_separator: H256 =
         serde_json::from_value(serde_json::Value::String(DOMAIN_SEPARATOR_TYPEHASH.into()))
             .unwrap();
@@ -93,7 +87,7 @@ fn zero_pad(input: Vec<u8>, final_length: usize) -> Vec<u8> {
 }
 
 // Maybe we could implement https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
-fn to_hex_string(input: Vec<u8>) -> String {
+pub fn to_hex_string(input: Vec<u8>) -> String {
     let mut output = String::new();
     for byte in input.iter() {
         output.push_str(&format!("{:02x?}", byte)) // uppercase x is for uppercase hex char.

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -20,8 +20,7 @@ pub fn fetch_rejections(context: &Context, safe_address: &str, nonce: u64) -> Op
     let safe_address: Address =
         serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
 
-    let safe_tx_hash = hash(safe_address, nonce).to_vec();
-    let safe_tx_hash = to_hex_string!(safe_tx_hash);
+    let safe_tx_hash = to_hex_string!(hash(safe_address, nonce).to_vec());
 
     let multisig_tx = fetch_cancellation_tx(context, safe_tx_hash);
     multisig_tx
@@ -85,6 +84,7 @@ pub(super) fn cancellation_parts_hash(safe_address: &Address, nonce: u64) -> [u8
     keccak256(encoded_parts)
 }
 
+// If there is an error while fetching the transaction we don't return the rejections
 fn fetch_cancellation_tx(context: &Context, safe_tx_hash: String) -> Option<MultisigTransaction> {
     let url = format!(
         "{}/v1/multisig-transactions/{}/",

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -71,7 +71,7 @@ pub(super) fn cancellation_parts_hash(safe_address: &Address, nonce: u64) -> [u8
     let encoded_parts = &ethabi::encode(&[
         ethabi::Token::Uint(Uint::from(safe_type_hash.0)),
         ethabi::Token::Address(Address::from(safe_address.0)), //to
-        ethabi::Token::Uint(Uint::zero()),                     // value
+        ethabi::Token::Uint(Uint::zero()),                     //value
         ethabi::Token::Uint(Uint::from(keccak256(vec![]))),    //data
         ethabi::Token::Uint(Uint::zero()),                     //operation
         ethabi::Token::Uint(Uint::zero()),                     //safe_tx_gas

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -1,67 +1,92 @@
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
+use crate::models::backend::transactions::MultisigTransaction;
+use crate::utils::cache::CacheExt;
 use crate::utils::context::Context;
 use ethcontract_common::hash::keccak256;
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
+use std::str::FromStr;
 
-pub fn fetch_rejections(context: &Context, safe_address: &str, nonce: &u64) -> Option<Vec<String>> {
-    log::debug!("{:#?}", &safe_address);
+pub const DOMAIN_SEPARATOR_TYPEHASH: &'static str =
+    "0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749";
+pub const SAFE_TX_TYPEHASH: &'static str =
+    "0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8";
 
-    // let safe_address: Address =
-    //     serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
-    // let nonce: Int = serde_json::from_str(nonce).unwrap();
+pub const ERC191_BYTE: &'static str = "0x19";
+pub const ERC191_VERSION: &'static str = "0x01";
 
-    // let hash = &ethabi::encode(&[
-    //     ethabi::Token::Address(safe_address),
-    //     ethabi::Token::Bytes(vec![0]),
-    //     ethabi::Token::Uint(U256::from(0)),
-    //     ethabi::Token::Uint(U256::from(0)),
-    // ]);
-    // log::debug!("{:#?}", hash);
+pub fn fetch_rejections(
+    context: &Context,
+    safe_address: &str,
+    to: &str,
+    nonce: u64,
+) -> Option<Vec<String>> {
+    let domain_hash = domain_hash(&safe_address);
+    let safe_address: Address =
+        serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
+    let to: Address =
+        serde_json::from_value(serde_json::value::Value::String(to.to_string())).unwrap();
 
-    // val to = when (val txInfo = transaction.txInfo) {
-    //     is TransactionInfo.Transfer -> {
-    //         when (val transferInfo = txInfo.transferInfo) {
-    //             is TransferInfo.Erc20Transfer -> {
-    //                 transferInfo.tokenAddress
-    //             }
-    //             is TransferInfo.Erc721Transfer -> {
-    //                 transferInfo.tokenAddress
-    //             }
-    //             is TransferInfo.EtherTransfer -> {
-    //                 txInfo.recipient
-    //             }
-    //         }
-    //     }
-    //     is TransactionInfo.Custom -> {
-    //         txInfo.to
-    //     }
-    //     is TransactionInfo.SettingsChange -> {
-    //         safeAddress
-    //     }
-    //     else -> {
-    //     throw UnsupportedTransactionType(transaction::javaClass.name)
-    //     }
-    // }.value.paddedHexString()
-    //
-    // val value = transaction.txData?.value.paddedHexString()
-    // val data = Sha3Utils.keccak(transaction.txData?.hexData?.hexToByteArray() ?: ByteArray(0)).toHex().padStart(64, '0')
-    // val operationString = (transaction.txData?.operation?.id?.toBigInteger() ?: BigInteger.ZERO).paddedHexString()
-    // val gasPriceString = executionInfo.gasPrice.paddedHexString()
-    // val txGasString = executionInfo.safeTxGas.paddedHexString()
-    // val dataGasString = executionInfo.baseGas.paddedHexString()
-    // val gasTokenString = executionInfo.gasToken.value.paddedHexString()
-    // val refundReceiverString = BigInteger.ZERO.paddedHexString()
-    // val nonce = executionInfo.nonce.paddedHexString()
+    let domain_separator: H256 = serde_json::from_value(serde_json::value::Value::String(
+        DOMAIN_SEPARATOR_TYPEHASH.to_string(),
+    ))
+    .unwrap();
 
-    log::error!("{:#?}", &ethabi::encode(&[ethabi::Token::Uint(0.into())]));
+    let tx_encoded = &ethabi::encode(&[
+        ethabi::Token::Bytes(ERC191_BYTE.into()),
+        ethabi::Token::Bytes(ERC191_VERSION.into()),
+        ethabi::Token::Bytes(domain_hash.into()),
+        ethabi::Token::Address(safe_address),
+        ethabi::Token::Address(to),
+        ethabi::Token::Uint(U256::zero()),       //value
+        ethabi::Token::Bytes(vec![0]),           //data, should calculate Keccak
+        ethabi::Token::Uint(U256::zero()),       //operation
+        ethabi::Token::Uint(U256::zero()),       //tx_gas
+        ethabi::Token::Uint(U256::zero()),       //base_gas
+        ethabi::Token::Address(Address::zero()), //gas_token
+        ethabi::Token::Address(Address::zero()), //refund_receiver
+        ethabi::Token::Uint(U256::from(nonce)),
+    ]);
+
+    let hash = H256::from(keccak256(tx_encoded));
+    log::error!("{:#?}", hash.to_string());
+
     None
+    // let url = format!(
+    //     "{}/v1/multisig-transactions/{}/",
+    //     base_transaction_service_url(),
+    //     safe_tx_hash
+    // );
+    // let body = context
+    //     .cache()
+    //     .request_cached(
+    //         &context.client(),
+    //         &url,
+    //         request_cache_duration(),
+    //         request_error_cache_timeout(),
+    //     )
+    //     .ok();
+    // let multisig_tx: Option<MultisigTransaction> = body
+    //     .as_ref()
+    //     .map(|body| serde_json::from_str::<MultisigTransaction>(body).ok())
+    //     .flatten();
+    //
+    // multisig_tx
+    //     .as_ref()
+    //     .map(|cancel_tx| {
+    //         cancel_tx.confirmations.as_ref().map(|confirmations| {
+    //             confirmations
+    //                 .iter()
+    //                 .map(|confirmation| confirmation.owner)
+    //                 .collect()
+    //         })
+    //     })
+    //     .flatten()
 }
 
-// Android uses 64 but that's because it is hex. In our case with u8 we should use 32
-fn zero_pad(input: Vec<u8>, final_length: usize) -> Vec<u8> {
-    let padding_length = final_length - input.len();
-    if padding_length > 0 {
-        [input, vec![0; padding_length]].concat()
-    } else {
-        input
-    }
+fn domain_hash(safe_address: &str) -> [u8; 32] {
+    let input = format!("{}{}", DOMAIN_SEPARATOR_TYPEHASH, safe_address);
+    let input_in_bytes: H256 = serde_json::from_value(serde_json::Value::String(input)).unwrap();
+    keccak256(input_in_bytes)
 }

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -14,8 +14,8 @@ pub const DOMAIN_SEPARATOR_TYPEHASH: &'static str =
 pub const SAFE_TX_TYPEHASH: &'static str =
     "0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8";
 
-pub const ERC191_BYTE: &'static str = "0x19";
-pub const ERC191_VERSION: &'static str = "0x01";
+pub const ERC191_BYTE: &'static str = "19";
+pub const ERC191_VERSION: &'static str = "01";
 
 pub fn fetch_rejections(
     context: &Context,
@@ -23,78 +23,110 @@ pub fn fetch_rejections(
     to: &str,
     nonce: u64,
 ) -> Option<Vec<String>> {
-    let domain_hash = domain_hash(&safe_address);
     let safe_address: Address =
         serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
     let to: Address =
         serde_json::from_value(serde_json::value::Value::String(to.to_string())).unwrap();
+    let hash = hash(&safe_address);
+    log::error!("{:#?}", to_hex_string(hash.into()));
 
-    let domain_separator: H256 = serde_json::from_value(serde_json::value::Value::String(
-        SAFE_TX_TYPEHASH.to_string(),
-    ))
-    .unwrap();
-
-    let tx_encoded = &ethabi::encode(&[
-        ethabi::Token::Bytes(ERC191_BYTE.into()),
-        ethabi::Token::Bytes(ERC191_VERSION.into()),
-        ethabi::Token::Bytes(domain_hash.into()),
-        ethabi::Token::Bytes(keccak256(domain_separator).into()),
-        ethabi::Token::Address(safe_address),
-        ethabi::Token::Address(to),
-        ethabi::Token::Uint(U256::zero()),               //value
-        ethabi::Token::Bytes(keccak256(vec![0]).into()), //data, should calculate Keccak
-        ethabi::Token::Uint(U256::zero()),               //operation
-        ethabi::Token::Uint(U256::zero()),               //tx_gas
-        ethabi::Token::Uint(U256::zero()),               //base_gas
-        ethabi::Token::Address(Address::zero()),         //gas_token
-        ethabi::Token::Address(Address::zero()),         //refund_receiver
-        ethabi::Token::Uint(U256::from(nonce)),
-    ]);
-
-    let hash = H256::from(keccak256(tx_encoded));
-    log::error!("{:#?}", hash.to_string());
+    //
+    // let tx_encoded = &ethabi::encode(&[
+    //     ethabi::Token::Bytes(ERC191_BYTE.into()),
+    //     ethabi::Token::Bytes(ERC191_VERSION.into()),
+    //     ethabi::Token::Bytes(domain_hash.into()),
+    //     ethabi::Token::Bytes(keccak256(domain_separator).into()),
+    //     ethabi::Token::Address(safe_address),
+    //     ethabi::Token::Address(to),
+    //     ethabi::Token::Uint(U256::zero()),               //value
+    //     ethabi::Token::Bytes(keccak256(vec![0]).into()), //data, should calculate Keccak
+    //     ethabi::Token::Uint(U256::zero()),               //operation
+    //     ethabi::Token::Uint(U256::zero()),               //tx_gas
+    //     ethabi::Token::Uint(U256::zero()),               //base_gas
+    //     ethabi::Token::Address(Address::zero()),         //gas_token
+    //     ethabi::Token::Address(Address::zero()),         //refund_receiver
+    //     ethabi::Token::Uint(U256::from(nonce)),
+    // ]);
+    //
+    // let hash = H256::from(keccak256(tx_encoded));
+    // log::error!("{:#?}", hash.to_string());
 
     // correct safe_tx_hash 0x931e3e46c1c06ad4449ae193d159dab9e24c50112682ffea083e0052ba53900b
     None
-    // let url = format!(
-    //     "{}/v1/multisig-transactions/{}/",
-    //     base_transaction_service_url(),
-    //     safe_tx_hash
-    // );
-    // let body = context
-    //     .cache()
-    //     .request_cached(
-    //         &context.client(),
-    //         &url,
-    //         request_cache_duration(),
-    //         request_error_cache_timeout(),
-    //     )
-    //     .ok();
-    // let multisig_tx: Option<MultisigTransaction> = body
-    //     .as_ref()
-    //     .map(|body| serde_json::from_str::<MultisigTransaction>(body).ok())
-    //     .flatten();
-    //
-    // multisig_tx
-    //     .as_ref()
-    //     .map(|cancel_tx| {
-    //         cancel_tx.confirmations.as_ref().map(|confirmations| {
-    //             confirmations
-    //                 .iter()
-    //                 .map(|confirmation| confirmation.owner)
-    //                 .collect()
-    //         })
-    //     })
-    //     .flatten()
 }
 
-fn domain_hash(safe_address: &str) -> [u8; 32] {
-    let domain_separator_hex =
-        &DOMAIN_SEPARATOR_TYPEHASH[2..DOMAIN_SEPARATOR_TYPEHASH.len()].to_string();
-    let safe_address_hex = &safe_address[2..safe_address.len()].to_string();
-    let input = format!("{}{}", domain_separator_hex, safe_address_hex);
-    log::error!("DOMAIN HASH: {}", &input);
-    // let input_in_bytes:  =
-    //     serde_json::from_value(serde_json::Value::String(input.to_string())).unwrap();
+fn hash(safe_address: &Address) -> [u8; 32] {
+    let erc_191_byte = u8::from_str_radix(ERC191_BYTE, 16).unwrap();
+    let erc_191_version = u8::from_str_radix(ERC191_VERSION, 16).unwrap();
+    let type_hash: H256 =
+        serde_json::from_value(serde_json::Value::String(SAFE_TX_TYPEHASH.into())).unwrap();
+
+    let mut hashable = vec![erc_191_byte, erc_191_version];
+
+    hashable.extend(domain_hash(safe_address).iter());
+    hashable.extend(keccak256(type_hash.0).iter());
+
+    return keccak256(hashable);
+}
+
+fn domain_hash(safe_address: &Address) -> [u8; 32] {
+    let domain_separator: H256 =
+        serde_json::from_value(serde_json::Value::String(DOMAIN_SEPARATOR_TYPEHASH.into()))
+            .unwrap();
+
+    let safe_address = zero_pad(safe_address.0.into(), 32);
+    let input = [domain_separator.0.to_vec(), safe_address].concat();
+
     keccak256(input)
 }
+
+// Android uses 64 but that's because it is hex. In our case with u8 we should use 32
+fn zero_pad(input: Vec<u8>, final_length: usize) -> Vec<u8> {
+    let padding_length = final_length - input.len();
+    if padding_length > 0 {
+        [vec![0; padding_length], input].concat()
+    } else {
+        input
+    }
+}
+
+// Maybe we could implement https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
+fn to_hex_string(input: Vec<u8>) -> String {
+    let mut output = String::new();
+    for byte in input.iter() {
+        output.push_str(&format!("{:02x?}", byte)) // uppercase x is for uppercase hex char.
+    }
+    output
+}
+
+// fetch the cancellation tx:
+// let url = format!(
+//     "{}/v1/multisig-transactions/{}/",
+//     base_transaction_service_url(),
+//     safe_tx_hash
+// );
+// let body = context
+//     .cache()
+//     .request_cached(
+//         &context.client(),
+//         &url,
+//         request_cache_duration(),
+//         request_error_cache_timeout(),
+//     )
+//     .ok();
+// let multisig_tx: Option<MultisigTransaction> = body
+//     .as_ref()
+//     .map(|body| serde_json::from_str::<MultisigTransaction>(body).ok())
+//     .flatten();
+//
+// multisig_tx
+//     .as_ref()
+//     .map(|cancel_tx| {
+//         cancel_tx.confirmations.as_ref().map(|confirmations| {
+//             confirmations
+//                 .iter()
+//                 .map(|confirmation| confirmation.owner)
+//                 .collect()
+//         })
+//     })
+//     .flatten()

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -84,7 +84,7 @@ pub(super) fn cancellation_parts_hash(safe_address: &Address, nonce: u64) -> [u8
     keccak256(encoded_parts)
 }
 
-// If there is an error while fetching the transaction we don't return the rejections
+// We silently fail if the cancellation transaction is not found
 fn fetch_cancellation_tx(context: &Context, safe_tx_hash: String) -> Option<MultisigTransaction> {
     let url = format!(
         "{}/v1/multisig-transactions/{}/",

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -1,11 +1,67 @@
-use ethabi::{Address, Int};
+use crate::utils::context::Context;
 use ethcontract_common::hash::keccak256;
+use ethereum_types::{Address, U256};
 
-fn build_cancellation_tx(safe_address: &str, nonce: &str) {
-    let safe_address: Address = serde_json::from_str(safe_address).unwrap();
-    let nonce: Int = serde_json::from_str(nonce).unwrap();
-    let hash = &ethabi::encode(&[
-        ethabi::Token::Address(safe_address),
-        ethabi::Token::Int(nonce),
-    ]);
+pub fn fetch_rejections(context: &Context, safe_address: &str, nonce: &u64) -> Option<Vec<String>> {
+    log::debug!("{:#?}", &safe_address);
+
+    // let safe_address: Address =
+    //     serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
+    // let nonce: Int = serde_json::from_str(nonce).unwrap();
+
+    // let hash = &ethabi::encode(&[
+    //     ethabi::Token::Address(safe_address),
+    //     ethabi::Token::Bytes(vec![0]),
+    //     ethabi::Token::Uint(U256::from(0)),
+    //     ethabi::Token::Uint(U256::from(0)),
+    // ]);
+    // log::debug!("{:#?}", hash);
+
+    // val to = when (val txInfo = transaction.txInfo) {
+    //     is TransactionInfo.Transfer -> {
+    //         when (val transferInfo = txInfo.transferInfo) {
+    //             is TransferInfo.Erc20Transfer -> {
+    //                 transferInfo.tokenAddress
+    //             }
+    //             is TransferInfo.Erc721Transfer -> {
+    //                 transferInfo.tokenAddress
+    //             }
+    //             is TransferInfo.EtherTransfer -> {
+    //                 txInfo.recipient
+    //             }
+    //         }
+    //     }
+    //     is TransactionInfo.Custom -> {
+    //         txInfo.to
+    //     }
+    //     is TransactionInfo.SettingsChange -> {
+    //         safeAddress
+    //     }
+    //     else -> {
+    //     throw UnsupportedTransactionType(transaction::javaClass.name)
+    //     }
+    // }.value.paddedHexString()
+    //
+    // val value = transaction.txData?.value.paddedHexString()
+    // val data = Sha3Utils.keccak(transaction.txData?.hexData?.hexToByteArray() ?: ByteArray(0)).toHex().padStart(64, '0')
+    // val operationString = (transaction.txData?.operation?.id?.toBigInteger() ?: BigInteger.ZERO).paddedHexString()
+    // val gasPriceString = executionInfo.gasPrice.paddedHexString()
+    // val txGasString = executionInfo.safeTxGas.paddedHexString()
+    // val dataGasString = executionInfo.baseGas.paddedHexString()
+    // val gasTokenString = executionInfo.gasToken.value.paddedHexString()
+    // val refundReceiverString = BigInteger.ZERO.paddedHexString()
+    // val nonce = executionInfo.nonce.paddedHexString()
+
+    log::error!("{:#?}", &ethabi::encode(&[ethabi::Token::Uint(0.into())]));
+    None
+}
+
+// Android uses 64 but that's because it is hex. In our case with u8 we should use 32
+fn zero_pad(input: Vec<u8>, final_length: usize) -> Vec<u8> {
+    let padding_length = final_length - input.len();
+    if padding_length > 0 {
+        [input, vec![0; padding_length]].concat()
+    } else {
+        input
+    }
 }

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -48,7 +48,7 @@ pub(super) fn hash(safe_address: Address, nonce: u64) -> [u8; 32] {
 
     encoded.insert(0, erc_191_version);
     encoded.insert(0, erc_191_byte);
-    return keccak256(encoded);
+    keccak256(encoded)
 }
 
 pub(super) fn domain_hash(safe_address: &Address) -> [u8; 32] {


### PR DESCRIPTION
Closes #258 

Changes:
- `MultisigExecutionDetails` now include a list of `rejectors`
- `SafeTxHash` calculation exclussively for cancellation works (Tests assume `safe_tx_gas == 0`, therefore test data generated with the current web app will not match the resulting hash)
- Made extensive use of `ethabi::encode` where possible (ERC191 bytes were padded when added there, so they had to be pushed directly into the vector, is this what encoded `packed` would have solved?)
- Added `to_hex_string` macro, I would like add `to_checksummed_hex_string` at some point. WDYT, @rmeissner ?