### PR TITLE
Info and Request error cache timeout added

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,7 +58,7 @@ pub fn internal_client_connect_timeout() -> u64 {
 }
 
 pub fn client_error_cache_duration() -> usize {
-    usize_with_default("CLIENT_ERROR_CACHE_DURATION", 3 * 10)
+    usize_with_default("CLIENT_ERROR_CACHE_DURATION", 60 * 3)
 }
 
 pub fn log_all_error_responses() -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -57,6 +57,10 @@ pub fn internal_client_connect_timeout() -> u64 {
     u64_with_default("INTERNAL_CLIENT_CONNECT_TIMEOUT", 1000)
 }
 
+pub fn client_error_cache_duration() -> usize {
+    usize_with_default("CLIENT_ERROR_CACHE_DURATION", 3 * 10)
+}
+
 pub fn log_all_error_responses() -> bool {
     bool_with_default("LOG_ALL_ERROR_RESPONSES", false)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -57,8 +57,12 @@ pub fn internal_client_connect_timeout() -> u64 {
     u64_with_default("INTERNAL_CLIENT_CONNECT_TIMEOUT", 1000)
 }
 
-pub fn client_error_cache_duration() -> usize {
-    usize_with_default("CLIENT_ERROR_CACHE_DURATION", 60 * 3)
+pub fn request_error_cache_timeout() -> usize {
+    usize_with_default("REQS_ERROR_CACHE_DURATION", 60)
+}
+
+pub fn info_error_cache_timeout() -> usize {
+    usize_with_default("INFO_ERROR_CACHE_DURATION", 60 * 60 * 24)
 }
 
 pub fn log_all_error_responses() -> bool {

--- a/src/routes/collectibles.rs
+++ b/src/routes/collectibles.rs
@@ -1,5 +1,5 @@
-use crate::config::base_transaction_service_url;
 use crate::config::request_cache_duration;
+use crate::config::{base_transaction_service_url, request_error_cache_timeout};
 use crate::utils::cache::CacheExt;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
@@ -25,5 +25,6 @@ pub fn list(
         &context.client(),
         url.as_str(),
         request_cache_duration(),
+        request_error_cache_timeout(),
     )?))
 }

--- a/src/services/balances.rs
+++ b/src/services/balances.rs
@@ -1,4 +1,6 @@
-use crate::config::{base_transaction_service_url, request_cache_duration};
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
 use crate::models::backend::balances::Balance as BalanceDto;
 use crate::models::service::balances::{Balance, Balances};
 use crate::providers::info::DefaultInfoProvider;
@@ -21,9 +23,12 @@ pub fn balances(
         exclude_spam
     );
 
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let backend_balances: Vec<BalanceDto> = serde_json::from_str(&body)?;
 
     let info_provider = DefaultInfoProvider::new(&context);

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -1,6 +1,8 @@
 extern crate reqwest;
 
-use crate::config::{base_transaction_service_url, request_cache_duration};
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::models::backend::transfers::Transfer;
 use crate::models::commons::Page;
@@ -26,9 +28,12 @@ pub(super) fn get_multisig_transaction_details(
         base_transaction_service_url(),
         safe_tx_hash
     );
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
     let details = multisig_tx.to_transaction_details(&mut info_provider)?;
 
@@ -49,9 +54,12 @@ fn get_ethereum_transaction_details(
         tx_hash
     );
     debug!("url: {}", url);
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let transfers: Page<Transfer> = serde_json::from_str(&body)?;
     let transfer = transfers
         .results
@@ -82,9 +90,12 @@ fn get_module_transaction_details(
         tx_hash
     );
     debug!("url: {}", url);
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let transactions: Page<ModuleTransaction> = serde_json::from_str(&body)?;
     let transaction = transactions
         .results

--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -1,6 +1,8 @@
 extern crate reqwest;
 
-use crate::config::{base_transaction_service_url, request_cache_duration};
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
 use crate::models::backend::transactions::Transaction;
 use crate::models::commons::{Page, PageMetadata};
 use crate::models::service::transactions::summary::{
@@ -122,9 +124,12 @@ fn fetch_backend_paged_txs(
         safe_address,
         page_metadata.to_url_string()
     );
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     log::debug!("request URL: {}", &url);
     log::debug!("page_url: {:#?}", page_url);
     log::debug!("page_metadata: {:#?}", page_metadata);

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -1,6 +1,8 @@
 extern crate reqwest;
 
-use crate::config::{base_transaction_service_url, request_cache_duration};
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
 use crate::models::backend::transactions::{CreationTransaction, Transaction};
 use crate::models::commons::Page;
 use crate::models::service::transactions::summary::TransactionSummary;
@@ -23,9 +25,12 @@ pub fn get_all_transactions(
         safe_address,
         page_url.as_ref().unwrap_or(&String::new())
     );
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     debug!("request URL: {}", &url);
     debug!("page_url: {:#?}", page_url);
     let backend_transactions: Page<Transaction> = serde_json::from_str(&body)?;
@@ -75,9 +80,12 @@ pub(super) fn get_creation_transaction_summary(
         safe
     );
     debug!("{}", &url);
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
 
     let creation_transaction_dto: CreationTransaction = serde_json::from_str(&body)?;
     let transaction_summary = creation_transaction_dto.to_transaction_summary(safe);

--- a/src/services/transactions_queued.rs
+++ b/src/services/transactions_queued.rs
@@ -1,4 +1,6 @@
-use crate::config::{base_transaction_service_url, request_cache_duration};
+use crate::config::{
+    base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+};
 use crate::models::backend::transactions::MultisigTransaction;
 use crate::models::commons::{Page, PageMetadata};
 use crate::models::service::transactions::summary::{ConflictType, Label, TransactionListItem};
@@ -38,9 +40,12 @@ pub fn get_queued_transactions(
         display_trusted_only
     );
 
-    let body = context
-        .cache()
-        .request_cached(&context.client(), &url, request_cache_duration())?;
+    let body = context.cache().request_cached(
+        &context.client(),
+        &url,
+        request_cache_duration(),
+        request_error_cache_timeout(),
+    )?;
     let mut backend_transactions: Page<MultisigTransaction> = serde_json::from_str(&body)?;
 
     // We need to do this before we create the iterator

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,4 +1,3 @@
-use crate::config::client_error_cache_duration;
 use crate::utils::errors::{ApiError, ApiResult};
 use mockall::automock;
 use rocket::response::content;
@@ -65,6 +64,7 @@ pub trait CacheExt: Cache {
         client: &reqwest::blocking::Client,
         url: &str,
         timeout: usize,
+        error_timeout: usize,
     ) -> ApiResult<String> {
         match self.fetch(&url) {
             Some(cached) => CachedWithCode::split(&cached).to_result(),
@@ -87,7 +87,7 @@ pub trait CacheExt: Cache {
                     self.create(
                         &url,
                         CachedWithCode::join(status_code, &raw_data).as_str(),
-                        client_error_cache_duration(),
+                        error_timeout,
                     );
                     Err(ApiError::from_backend_error(status_code, &raw_data))
                 } else {


### PR DESCRIPTION
Closes #246 

Changes:
- Added `REQS_ERROR_CACHE_DURATION` and `INFO_ERROR_CACHE_DURATION` env vars
- Default is 1 minute and 24 hours respectively
- Only 4xx errors are cached (old behaviour is preserved)