### PR TITLE
Overhauled cache durations

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -80,7 +80,7 @@ pub fn short_error_duration() -> usize {
 }
 
 pub fn long_error_duration() -> usize {
-    usize_with_default("LONG_ERROR", 60 * 60 * 24)
+    usize_with_default("LONG_ERROR_DURATION", 60 * 60 * 24)
 }
 
 pub fn log_all_error_responses() -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,6 +37,14 @@ fn indefinite_timeout() -> usize {
     usize_with_default("INDEFINITE_TIMEOUT", 60 * 60 * 24 * 7)
 }
 
+pub fn short_error_duration() -> usize {
+    usize_with_default("SHORT_ERROR_DURATION", 60)
+}
+
+pub fn long_error_duration() -> usize {
+    usize_with_default("LONG_ERROR_DURATION", 60 * 60 * 24)
+}
+
 // FUNCTIONAL TIMEOUTS
 pub fn safe_info_cache_duration() -> usize {
     usize_with_default("SAFE_INFO_CACHE_DURATION", indefinite_timeout())
@@ -73,14 +81,6 @@ pub fn internal_client_connect_timeout() -> u64 {
 
 pub fn request_error_cache_timeout() -> usize {
     usize_with_default("REQS_ERROR_CACHE_DURATION", short_error_duration())
-}
-
-pub fn short_error_duration() -> usize {
-    usize_with_default("SHORT_ERROR_DURATION", 60)
-}
-
-pub fn long_error_duration() -> usize {
-    usize_with_default("LONG_ERROR_DURATION", 60 * 60 * 24)
 }
 
 pub fn log_all_error_responses() -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,9 +32,22 @@ fn bool_with_default(key: &str, default: bool) -> bool {
         Err(_) => default,
     }
 }
+// TIME DURATION VALUES
+fn indefinite_timeout() -> usize {
+    usize_with_default("INDEFINITE_TIMEOUT", 60 * 60 * 24 * 7)
+}
 
-pub fn info_cache_duration() -> usize {
-    usize_with_default("INFO_CACHE_DURATION", 60 * 15)
+// FUNCTIONAL TIMEOUTS
+pub fn safe_info_cache_duration() -> usize {
+    usize_with_default("SAFE_INFO_CACHE_DURATION", indefinite_timeout())
+}
+
+pub fn address_info_cache_duration() -> usize {
+    usize_with_default("ADDRESS_INFO_CACHE_DURATION", indefinite_timeout())
+}
+
+pub fn token_info_cache_duration() -> usize {
+    usize_with_default("TOKEN_INFO_CACHE_DURATION", 60 * 60 * 24)
 }
 
 pub fn exchange_api_cache_duration() -> usize {
@@ -42,27 +55,32 @@ pub fn exchange_api_cache_duration() -> usize {
 }
 
 pub fn request_cache_duration() -> usize {
-    usize_with_default("REQUEST_CACHE_DURATION", 60 * 15)
+    usize_with_default("REQUEST_CACHE_DURATION", indefinite_timeout())
 }
 
 pub fn about_cache_duration() -> usize {
-    usize_with_default("ABOUT_CACHE_DURATION", request_cache_duration())
+    usize_with_default("ABOUT_CACHE_DURATION", 60 * 15)
 }
 
-pub fn safe_app_manifest_cache() -> usize {
-    usize_with_default("SAFE_APP_MANIFEST_CACHE_DURATION", 60 * 60 * 24 * 7)
+pub fn safe_app_manifest_cache_duration() -> usize {
+    usize_with_default("SAFE_APP_MANIFEST_CACHE_DURATION", indefinite_timeout())
 }
 
+//ERRORS
 pub fn internal_client_connect_timeout() -> u64 {
     u64_with_default("INTERNAL_CLIENT_CONNECT_TIMEOUT", 1000)
 }
 
 pub fn request_error_cache_timeout() -> usize {
-    usize_with_default("REQS_ERROR_CACHE_DURATION", 60)
+    usize_with_default("REQS_ERROR_CACHE_DURATION", short_error_duration())
 }
 
-pub fn info_error_cache_timeout() -> usize {
-    usize_with_default("INFO_ERROR_CACHE_DURATION", 60 * 60 * 24)
+pub fn short_error_duration() -> usize {
+    usize_with_default("SHORT_ERROR_DURATION", 60)
+}
+
+pub fn long_error_duration() -> usize {
+    usize_with_default("LONG_ERROR", 60 * 60 * 24)
 }
 
 pub fn log_all_error_responses() -> bool {

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -1,6 +1,7 @@
 use crate::config::{
-    base_transaction_service_url, exchange_api_cache_duration, info_cache_duration,
-    info_error_cache_timeout, safe_app_manifest_cache,
+    address_info_cache_duration, base_transaction_service_url, exchange_api_cache_duration,
+    long_error_duration, request_cache_duration, safe_app_manifest_cache_duration,
+    safe_info_cache_duration, short_error_duration, token_info_cache_duration,
 };
 use crate::models::commons::Page;
 use crate::providers::address_info::{AddressInfo, ContractInfo};
@@ -108,8 +109,8 @@ impl InfoProvider for DefaultInfoProvider<'_> {
         let manifest_json = self.cache.request_cached(
             self.client,
             &manifest_url,
-            safe_app_manifest_cache(),
-            info_error_cache_timeout(),
+            safe_app_manifest_cache_duration(),
+            long_error_duration(),
         )?;
         let manifest = serde_json::from_str::<Manifest>(&manifest_json)?;
         Ok(SafeAppInfo {
@@ -134,8 +135,8 @@ impl InfoProvider for DefaultInfoProvider<'_> {
                 let contract_info_json = self.cache.request_cached(
                     self.client,
                     &url,
-                    safe_app_manifest_cache(),
-                    info_error_cache_timeout(),
+                    address_info_cache_duration(),
+                    long_error_duration(),
                 )?;
                 let contract_info = serde_json::from_str::<ContractInfo>(&contract_info_json)?;
                 if contract_info.display_name.trim().is_empty() {
@@ -187,8 +188,8 @@ impl DefaultInfoProvider<'_> {
         let data: String = self.cache.request_cached(
             self.client,
             &url,
-            info_cache_duration(),
-            info_cache_duration(),
+            safe_info_cache_duration(),
+            short_error_duration(),
         )?;
         Ok(serde_json::from_str(&data).unwrap_or(None))
     }
@@ -201,7 +202,7 @@ impl DefaultInfoProvider<'_> {
             self.cache.create(
                 &format!("dip_ti_{}", token.address),
                 &serde_json::to_string(&token)?,
-                info_cache_duration(),
+                request_cache_duration(),
             )
         }
         Ok(())
@@ -218,9 +219,9 @@ impl DefaultInfoProvider<'_> {
             "dip_tcl",
             "",
             if result.is_ok() {
-                info_cache_duration()
+                token_info_cache_duration()
             } else {
-                info_error_cache_timeout()
+                short_error_duration()
             },
         );
         result
@@ -260,7 +261,7 @@ impl DefaultInfoProvider<'_> {
             self.client,
             &url,
             exchange_api_cache_duration(),
-            info_cache_duration(),
+            short_error_duration(),
         )?;
         Ok(serde_json::from_str::<Exchange>(&body)?)
     }


### PR DESCRIPTION
Closes #278 

Overhauled cache durations according to https://github.com/gnosis/safe-client-gateway/issues/278#issuecomment-786650720

Remaining TODO's: 
- Notify devOps about deprecation of `INFO_CACHE_DURATION` 