### PR TITLE
Added a catcher for 422s

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -32,15 +32,7 @@ pub fn active_routes() -> Vec<Route> {
 }
 
 pub fn error_catchers() -> Vec<Catcher> {
-    catchers![unprocessable_entity, not_found, panic]
-}
-
-#[catch(422)]
-fn unprocessable_entity() -> JsonValue {
-    json!({
-        "status": "error",
-        "reason": "Unprocessable Entity."
-    })
+    catchers![not_found, panic]
 }
 
 #[catch(404)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -32,7 +32,15 @@ pub fn active_routes() -> Vec<Route> {
 }
 
 pub fn error_catchers() -> Vec<Catcher> {
-    catchers![not_found, panic]
+    catchers![unprocessable_entity, not_found, panic]
+}
+
+#[catch(422)]
+fn unprocessable_entity() -> JsonValue {
+    json!({
+        "status": "error",
+        "reason": "Unprocessable Entity."
+    })
 }
 
 #[catch(404)]

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -11,6 +11,7 @@ use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 use rocket_contrib::json::Json;
+use rocket_contrib::json::JsonError;
 
 #[get("/v1/safes/<safe_address>/transactions?<page_url>")]
 pub fn all(
@@ -36,17 +37,18 @@ pub fn details(context: Context, details_id: String) -> ApiResult<content::Json<
 
 #[post(
     "/v1/transactions/<safe_tx_hash>/confirmations",
+    format = "application/json",
     data = "<tx_confirmation_request>"
 )]
 pub fn submit_confirmation(
     context: Context,
     safe_tx_hash: String,
-    tx_confirmation_request: Json<ConfirmationRequest>,
+    tx_confirmation_request: Result<Json<ConfirmationRequest>, JsonError>,
 ) -> ApiResult<content::Json<String>> {
     transactions_proposal::submit_confirmation(
         &context,
         &safe_tx_hash,
-        &tx_confirmation_request.signed_safe_tx_hash,
+        &tx_confirmation_request?.0.signed_safe_tx_hash,
     )
     .and_then(|_| {
         context
@@ -99,16 +101,17 @@ pub fn queued_transactions(
 
 #[post(
     "/v1/transactions/<safe_address>/propose",
+    format = "application/json",
     data = "<multisig_transaction_request>"
 )]
 pub fn propose_transaction(
     context: Context,
     safe_address: String,
-    multisig_transaction_request: Json<MultisigTransactionRequest>,
+    multisig_transaction_request: Result<Json<MultisigTransactionRequest>, JsonError>,
 ) -> ApiResult<()> {
     transactions_proposal::propose_transaction(
         &context,
         &safe_address,
-        &multisig_transaction_request,
+        &multisig_transaction_request?.0,
     )
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -3,6 +3,7 @@ use reqwest::blocking::Response as ReqwestResponse;
 use rocket::http::{ContentType, Status};
 use rocket::request::Request;
 use rocket::response::{self, Responder, Response};
+use rocket_contrib::json::JsonError;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fmt;
@@ -121,5 +122,15 @@ impl From<reqwest::Error> for ApiError {
 impl From<serde_json::error::Error> for ApiError {
     fn from(err: serde_json::error::Error) -> Self {
         Self::new_from_message(format!("{:?}", err))
+    }
+}
+
+impl From<rocket_contrib::json::JsonError<'_>> for ApiError {
+    fn from(err: JsonError<'_>) -> Self {
+        let message = match err {
+            JsonError::Io(_) => String::from("Request deserialize IO error"),
+            JsonError::Parse(_request_json, json_error) => json_error.to_string(),
+        };
+        Self::new_from_message_with_code(422, message)
     }
 }


### PR DESCRIPTION
Closes #277 

Changes:
- Added error catcher for 422s

Note: It seems like rocket has built-in helpful error catchers that trigger the behaviour reported by Dirk: https://api.rocket.rs/v0.4/rocket/struct.Catcher.html#built-in-catchers

Do we add more catchers for common and expected error codes? For now I just covered the one that Dirk encountered.
