### PR TITLE
Added AddressInfo fields to CreationTransaction

### DIFF
--- a/src/models/converters/transactions/summary.rs
+++ b/src/models/converters/transactions/summary.rs
@@ -119,16 +119,31 @@ impl ModuleTransaction {
 }
 
 impl CreationTransaction {
-    pub fn to_transaction_summary(&self, safe_address: &String) -> TransactionSummary {
+    pub fn to_transaction_summary(
+        &self,
+        safe_address: &String,
+        info_provider: &mut dyn InfoProvider,
+    ) -> TransactionSummary {
         TransactionSummary {
             id: create_id!(ID_PREFIX_CREATION_TX, safe_address),
             timestamp: self.created.timestamp_millis(),
             tx_status: TransactionStatus::Success,
             tx_info: TransactionInfo::Creation(Creation {
                 creator: self.creator.clone(),
+                creator_info: info_provider.address_info(&self.creator).ok(),
                 transaction_hash: self.transaction_hash.clone(),
                 implementation: self.master_copy.clone(),
+                implementation_info: self
+                    .master_copy
+                    .as_ref()
+                    .map(|address| info_provider.address_info(address).ok())
+                    .flatten(),
                 factory: self.factory_address.clone(),
+                factory_info: self
+                    .factory_address
+                    .as_ref()
+                    .map(|address| info_provider.address_info(address).ok())
+                    .flatten(),
             }),
             execution_info: None,
             safe_app_info: None,

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -188,7 +188,13 @@ pub struct Custom {
 #[serde(rename_all = "camelCase")]
 pub struct Creation {
     pub creator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_info: Option<AddressInfo>,
     pub transaction_hash: String,
     pub implementation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implementation_info: Option<AddressInfo>,
     pub factory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub factory_info: Option<AddressInfo>,
 }

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -87,7 +87,10 @@ pub(super) fn get_creation_transaction_summary(
         request_error_cache_timeout(),
     )?;
 
+    let mut info_provider = DefaultInfoProvider::new(context);
+
     let creation_transaction_dto: CreationTransaction = serde_json::from_str(&body)?;
-    let transaction_summary = creation_transaction_dto.to_transaction_summary(safe);
+    let transaction_summary =
+        creation_transaction_dto.to_transaction_summary(safe, &mut info_provider);
     Ok(transaction_summary)
 }


### PR DESCRIPTION
Closes #245 

Changes:
- Added `creator_info`, `factory_info` and `implementation_info` fields of `AddressInfo` type
- Unit tests
