### PR TITLE
Use custom scan count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "cargo-watch",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "1.9.1"
+version = "1.9.2"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>"]
 edition = "2018"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -78,7 +78,7 @@ pub fn safe_app_manifest_cache_duration() -> usize {
     usize_with_default("SAFE_APP_MANIFEST_CACHE_DURATION", indefinite_timeout())
 }
 
-//ERRORS
+// ERRORS
 pub fn internal_client_connect_timeout() -> u64 {
     u64_with_default("INTERNAL_CLIENT_CONNECT_TIMEOUT", 1000)
 }
@@ -89,6 +89,11 @@ pub fn request_error_cache_timeout() -> usize {
 
 pub fn log_all_error_responses() -> bool {
     bool_with_default("LOG_ALL_ERROR_RESPONSES", false)
+}
+
+// OTHERS
+pub fn redis_scan_count() -> usize {
+    usize_with_default("REDIS_SCAN_COUNT", 300)
 }
 
 pub fn build_number() -> Option<String> {

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -57,10 +57,7 @@ impl Cache for ServiceCache {
     }
 
     fn invalidate_pattern(&self, pattern: &str) {
-        pipeline_delete(
-            self,
-            scan_match_count(self, pattern, redis_scan_count()).unwrap(),
-        );
+        pipeline_delete(self, scan_match_count(self, pattern, redis_scan_count()));
     }
 
     fn invalidate(&self, id: &str) {
@@ -196,7 +193,7 @@ fn scan_match_count<P: ToRedisArgs, C: ToRedisArgs, RV: FromRedisValue>(
     con: &redis::Connection,
     pattern: P,
     count: C,
-) -> redis::RedisResult<redis::Iter<RV>> {
+) -> redis::Iter<RV> {
     redis::cmd("INFO")
         .cursor_arg(0)
         .arg("MATCH")
@@ -204,6 +201,7 @@ fn scan_match_count<P: ToRedisArgs, C: ToRedisArgs, RV: FromRedisValue>(
         .arg("COUNT")
         .arg(count)
         .iter(con)
+        .unwrap()
 }
 
 fn info(con: &redis::Connection) -> Option<String> {

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -192,11 +192,11 @@ fn pipeline_delete(con: &redis::Connection, keys: Iter<String>) {
     pipeline.execute(con);
 }
 
-fn scan_match_count<'a, P: ToRedisArgs, C: ToRedisArgs, RV: FromRedisValue>(
-    con: &'a redis::Connection,
+fn scan_match_count<P: ToRedisArgs, C: ToRedisArgs, RV: FromRedisValue>(
+    con: &redis::Connection,
     pattern: P,
     count: C,
-) -> redis::RedisResult<redis::Iter<'a, RV>> {
+) -> redis::RedisResult<redis::Iter<RV>> {
     redis::cmd("INFO")
         .cursor_arg(0)
         .arg("MATCH")


### PR DESCRIPTION
- Allow to set the count for scan -> new `scan_match_count` function. 
- Introduce env variable for scan count -> `REDIS_SCAN_COUNT` (default `300`)

More info https://docs.keydb.dev/blog/2020/08/10/blog-post/
