### PR TITLE
Sorted fiat codes according to spec: USD, EUR, rest in alphabetical order

### DIFF
--- a/src/routes/balances.rs
+++ b/src/routes/balances.rs
@@ -1,5 +1,4 @@
 use crate::config::{balances_cache_duration, request_cache_duration};
-use crate::providers::info::DefaultInfoProvider;
 use crate::services::balances::*;
 use crate::utils::cache::CacheExt;
 use crate::utils::context::Context;
@@ -34,7 +33,6 @@ pub fn get_supported_fiat(context: Context) -> ApiResult<content::Json<String>> 
     context
         .cache()
         .cache_resp(&context.uri(), request_cache_duration(), || {
-            let info_provider = DefaultInfoProvider::new(&context);
-            Ok(info_provider.available_currency_codes()?)
+            fiat_codes(&context)
         })
 }

--- a/src/services/balances.rs
+++ b/src/services/balances.rs
@@ -50,3 +50,21 @@ pub fn balances(
         items: service_balances,
     })
 }
+
+pub fn fiat_codes(context: &Context) -> ApiResult<Vec<String>> {
+    let info_provider = DefaultInfoProvider::new(&context);
+    let mut fiat_codes = info_provider.available_currency_codes()?;
+
+    let usd_index = fiat_codes.iter().position(|it| it.eq("USD")).unwrap();
+    let eur_index = fiat_codes.iter().position(|it| it.eq("EUR")).unwrap();
+
+    let usd_code = fiat_codes.swap_remove(usd_index);
+    let eur_code = fiat_codes.swap_remove(eur_index);
+
+    fiat_codes.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+
+    let mut output = vec![usd_code, eur_code];
+    output.append(&mut fiat_codes);
+
+    Ok(output)
+}


### PR DESCRIPTION
Closes #314 

- Sorted fiat codes returned by `/v1/balances/supported-fiat-codes` as USD, EUR and rest in alphabetical order
