### PR TITLE
Feature/issue 292 decouple address info

### DIFF
--- a/src/models/converters/data_decoded.rs
+++ b/src/models/converters/data_decoded.rs
@@ -22,7 +22,7 @@ impl DataDecoded {
             ADD_OWNER_WITH_THRESHOLD => {
                 let owner = self.get_parameter_single_value_at(0)?;
                 Some(SettingsInfo::AddOwner {
-                    owner_info: info_provider.address_info(&owner).ok(),
+                    owner_info: None,
                     owner,
                     threshold: self.get_parameter_single_value_at(1)?.parse().ok()?,
                 })
@@ -30,7 +30,7 @@ impl DataDecoded {
             REMOVE_OWNER => {
                 let owner = self.get_parameter_single_value_at(1)?;
                 Some(SettingsInfo::RemoveOwner {
-                    owner_info: info_provider.address_info(&owner).ok(),
+                    owner_info: None,
                     owner,
                     threshold: self.get_parameter_single_value_at(2)?.parse().ok()?,
                 })
@@ -39,9 +39,9 @@ impl DataDecoded {
                 let old_owner = self.get_parameter_single_value_at(1)?;
                 let new_owner = self.get_parameter_single_value_at(2)?;
                 Some(SettingsInfo::SwapOwner {
-                    old_owner_info: info_provider.address_info(&old_owner).ok(),
+                    old_owner_info: None,
                     old_owner,
-                    new_owner_info: info_provider.address_info(&new_owner).ok(),
+                    new_owner_info: None,
                     new_owner,
                 })
             }

--- a/src/models/converters/mod.rs
+++ b/src/models/converters/mod.rs
@@ -28,10 +28,10 @@ pub(super) fn get_transfer_direction(safe: &str, from: &str, to: &str) -> Transf
 pub(super) fn get_address_info(
     safe: &str,
     address: &str,
-    info_provide: &mut dyn InfoProvider,
+    info_provider: &mut dyn InfoProvider,
 ) -> Option<AddressInfo> {
     if safe != address {
-        info_provide.address_info(address).ok()
+        info_provider.full_address_info_search(address).ok()
     } else {
         None
     }

--- a/src/models/converters/tests/data_decoded.rs
+++ b/src/models/converters/tests/data_decoded.rs
@@ -66,8 +66,7 @@ fn data_decoded_add_owner_with_threshold_to_settings_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| bail!("Some http error"));
+        .times(0);
 
     let data_decoded =
         serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_ADD_OWNER_WITH_THRESHOLD)
@@ -92,13 +91,7 @@ fn data_decoded_add_owner_with_threshold_to_settings_info_with_address_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| {
-            Ok(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            })
-        });
+        .times(0);
 
     let data_decoded =
         serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_ADD_OWNER_WITH_THRESHOLD)
@@ -108,10 +101,7 @@ fn data_decoded_add_owner_with_threshold_to_settings_info_with_address_info() {
         data_decoded: data_decoded.clone(),
         settings_info: Some(SettingsInfo::AddOwner {
             owner: "0xBEA2F9227230976d2813a2f8b922c22bE1DE1B23".to_string(),
-            owner_info: Some(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            }),
+            owner_info: None,
             threshold: 1,
         }),
     };
@@ -126,8 +116,7 @@ fn data_decoded_remove_owner_to_settings_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| bail!("Some http error"));
+        .times(0);
 
     let data_decoded =
         serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_REMOVE_OWNER).unwrap();
@@ -147,45 +136,11 @@ fn data_decoded_remove_owner_to_settings_info() {
 }
 
 #[test]
-fn data_decoded_remove_owner_to_settings_info_with_address_info() {
-    let mut mock_info_provider = MockInfoProvider::new();
-    mock_info_provider
-        .expect_address_info()
-        .times(1)
-        .return_once(move |_| {
-            Ok(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            })
-        });
-
-    let data_decoded =
-        serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_REMOVE_OWNER).unwrap();
-
-    let expected = SettingsChange {
-        data_decoded: data_decoded.clone(),
-        settings_info: Some(SettingsInfo::RemoveOwner {
-            owner: "0xF2CeA96575d6b10f51d9aF3b10e3e4E5738aa6bd".to_string(),
-            owner_info: Some(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            }),
-            threshold: 2,
-        }),
-    };
-
-    let actual = DataDecoded::to_settings_info(&data_decoded, &mut mock_info_provider);
-
-    assert_eq!(expected.settings_info, actual);
-}
-
-#[test]
 fn data_decoded_swap_owner_to_settings_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
         .expect_address_info()
-        .times(2)
-        .returning(move |_| bail!("Some http error"));
+        .times(0);
 
     let data_decoded =
         serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_SWAP_OWNER).unwrap();
@@ -197,43 +152,6 @@ fn data_decoded_swap_owner_to_settings_info() {
             old_owner_info: None,
             new_owner: "0xF2CeA96575d6b10f51d9aF3b10e3e4E5738aa6bd".to_string(),
             new_owner_info: None,
-        }),
-    };
-
-    let actual = DataDecoded::to_settings_info(&data_decoded, &mut mock_info_provider);
-
-    assert_eq!(expected.settings_info, actual);
-}
-
-#[test]
-fn data_decoded_swap_owner_to_settings_info_with_address_info() {
-    let mut mock_info_provider = MockInfoProvider::new();
-    mock_info_provider
-        .expect_address_info()
-        .times(2)
-        .returning(move |_| {
-            Ok(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            })
-        });
-
-    let data_decoded =
-        serde_json::from_str::<DataDecoded>(crate::json::DATA_DECODED_SWAP_OWNER).unwrap();
-
-    let expected = SettingsChange {
-        data_decoded: data_decoded.clone(),
-        settings_info: Some(SettingsInfo::SwapOwner {
-            old_owner: "0xA3DAa0d9Ae02dAA17a664c232aDa1B739eF5ae8D".to_string(),
-            old_owner_info: Some(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            }),
-            new_owner: "0xF2CeA96575d6b10f51d9aF3b10e3e4E5738aa6bd".to_string(),
-            new_owner_info: Some(AddressInfo {
-                name: "Address name".to_string(),
-                logo_uri: Some("logo.url".to_string()),
-            }),
         }),
     };
 
@@ -451,7 +369,7 @@ fn data_decoded_with_nested_safe_transaction() {
     let data_decoded = serde_json::from_str::<DataDecoded>(
         crate::json::DATA_DECODED_EXEC_TRANSACTION_WITH_VALUE_DECODED,
     )
-    .unwrap();
+        .unwrap();
 
     let expected = DataDecoded {
         method: "execTransaction".to_string(),

--- a/src/models/converters/tests/get_address_info.rs
+++ b/src/models/converters/tests/get_address_info.rs
@@ -9,7 +9,7 @@ fn get_address_info_address_diff_than_safe() {
 
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {
@@ -35,7 +35,7 @@ fn get_address_info_address_diff_than_safe_error() {
 
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 

--- a/src/models/converters/tests/transfer_erc20.rs
+++ b/src/models/converters/tests/transfer_erc20.rs
@@ -17,7 +17,7 @@ fn erc20_transfer_dto_to_incoming_transfer_transaction() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -59,7 +59,7 @@ fn erc20_transfer_dto_to_incoming_transfer_transaction_with_address_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {
@@ -109,7 +109,7 @@ fn erc20_transfer_dto_to_outgoing_transfer_transaction_with_address_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {

--- a/src/models/converters/tests/transfer_erc721.rs
+++ b/src/models/converters/tests/transfer_erc721.rs
@@ -17,7 +17,7 @@ fn erc721_transfer_dto_to_incoming_transfer_transaction() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -58,7 +58,7 @@ fn erc721_transfer_dto_to_incoming_transfer_transaction_with_address_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {
@@ -104,7 +104,7 @@ fn erc721_transfer_dto_to_outgoing_transfer_transaction_with_address_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {

--- a/src/models/converters/tests/transfer_ether.rs
+++ b/src/models/converters/tests/transfer_ether.rs
@@ -11,7 +11,7 @@ use crate::providers::info::*;
 fn ether_transfer_dto_ether_incoming_transfer_transaction() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("no address info"));
 
@@ -42,7 +42,7 @@ fn ether_transfer_dto_ether_incoming_transfer_transaction() {
 fn ether_transfer_dto_ether_incoming_transfer_transaction_with_address_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {
@@ -81,7 +81,7 @@ fn ether_transfer_dto_ether_incoming_transfer_transaction_with_address_info() {
 fn ether_transfer_dto_ether_outgoing_transfer_transaction_with_address_info() {
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {

--- a/src/models/converters/tests/transfers.rs
+++ b/src/models/converters/tests/transfers.rs
@@ -23,7 +23,7 @@ fn erc_20_transfer_dto_to_transaction_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -64,7 +64,7 @@ fn erc_721_transfer_dto_to_transaction_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -101,7 +101,7 @@ fn ether_transfer_dto_to_transaction_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -165,7 +165,7 @@ fn transfer_dto_to_transaction_details() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -203,7 +203,7 @@ fn transfer_erc20_transfer_with_erc721_token_info_returns_transfer_tx() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -76,9 +76,9 @@ impl MultisigTransaction {
             && data_size > 0
             && self.safe == self.to
             && self
-                .data_decoded
-                .as_ref()
-                .map_or_else(|| false, |it| it.is_settings_change())
+            .data_decoded
+            .as_ref()
+            .map_or_else(|| false, |it| it.is_settings_change())
         {
             TransactionInfo::SettingsChange(self.to_settings_change(info_provider))
         } else if self
@@ -171,7 +171,7 @@ impl MultisigTransaction {
         Transfer {
             sender_info: None,
             sender: self.safe.to_owned(),
-            recipient_info: info_provider.address_info(&self.to).ok(),
+            recipient_info: info_provider.full_address_info_search(&self.to).ok(),
             recipient: self.to.to_owned(),
             direction: TransferDirection::Outgoing,
             transfer_info: TransferInfo::Ether(EtherTransfer {
@@ -193,7 +193,7 @@ impl MultisigTransaction {
     fn to_custom(&self, info_provider: &mut dyn InfoProvider) -> Custom {
         Custom {
             to: self.to.to_owned(),
-            to_info: info_provider.address_info(&self.to).ok(),
+            to_info: info_provider.full_address_info_search(&self.to).ok(),
             is_cancellation: self.is_cancellation(),
             data_size: data_size(&self.data).to_string(),
             value: self.value.as_ref().unwrap().into(),
@@ -218,32 +218,32 @@ impl MultisigTransaction {
             && data_size(&self.data) == 0
             && self.value.as_ref().map_or(true, |value| value == "0")
             && self
-                .operation
-                .map_or(true, |operation| operation == Operation::CALL)
+            .operation
+            .map_or(true, |operation| operation == Operation::CALL)
             && self
-                .base_gas
-                .as_ref()
-                .map_or(true, |base_gas| base_gas.eq(&0))
+            .base_gas
+            .as_ref()
+            .map_or(true, |base_gas| base_gas.eq(&0))
             && self
-                .gas_price
-                .as_ref()
-                .map_or(true, |gas_price| gas_price == "0")
+            .gas_price
+            .as_ref()
+            .map_or(true, |gas_price| gas_price == "0")
             && self.gas_token.as_ref().map_or(true, |gas_token| {
-                gas_token == "0x0000000000000000000000000000000000000000"
-            })
+            gas_token == "0x0000000000000000000000000000000000000000"
+        })
             && self
-                .refund_receiver
-                .as_ref()
-                .map_or(true, |refund_receiver| {
-                    refund_receiver == "0x0000000000000000000000000000000000000000"
-                })
+            .refund_receiver
+            .as_ref()
+            .map_or(true, |refund_receiver| {
+                refund_receiver == "0x0000000000000000000000000000000000000000"
+            })
     }
 }
 
 impl ModuleTransaction {
     fn to_transaction_info(&self, info_provider: &mut dyn InfoProvider) -> TransactionInfo {
         TransactionInfo::Custom(Custom {
-            to_info: info_provider.address_info(&self.to).ok(),
+            to_info: info_provider.full_address_info_search(&self.to).ok(),
             to: self.to.to_owned(),
             data_size: data_size(&self.data).to_string(),
             value: self.value.as_ref().unwrap_or(&String::from("0")).clone(),

--- a/src/models/converters/transactions/tests/details.rs
+++ b/src/models/converters/transactions/tests/details.rs
@@ -33,7 +33,7 @@ fn multisig_custom_transaction_to_transaction_details() {
         .times(1)
         .returning(move |_| bail!("Token Address 0x0"));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .returning(move |_| bail!("No address info"));
 
@@ -121,7 +121,7 @@ fn module_transaction_to_transaction_details() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .returning(move |_| bail!("No address info"));
 
@@ -196,7 +196,7 @@ fn ethereum_tx_transfer_to_transaction_details() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -237,7 +237,7 @@ fn multisig_transaction_with_origin() {
             })
         });
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("no address info"));
 

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -46,7 +46,7 @@ fn module_tx_to_summary_transaction() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .returning(move |_| bail!("No address info"));
 
@@ -119,7 +119,7 @@ fn ethereum_tx_to_summary_transaction_with_transfers() {
     let safe_address = String::from("0x2323");
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(4)
         .returning(move |_| bail!("No address info"));
     let timestamp = Utc::now();
@@ -329,7 +329,7 @@ fn multisig_transaction_to_erc20_transfer_summary() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -384,7 +384,7 @@ fn multisig_transaction_to_erc721_transfer_summary() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -434,7 +434,7 @@ fn multisig_transaction_to_ether_transfer_summary() {
         .return_once(move |_| Ok(safe_info));
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -548,7 +548,7 @@ fn multisig_transaction_to_custom_summary() {
         .return_once(move |_| Ok(safe_info));
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -600,7 +600,7 @@ fn multisig_transaction_with_missing_signers() {
         .return_once(move |_| Ok(safe_info));
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -652,7 +652,7 @@ fn ethereum_transaction_with_inconsistent_token_types() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -706,7 +706,7 @@ fn multisig_transaction_with_origin() {
         .times(1)
         .return_once(move |_| Ok(safe_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
     mock_info_provider

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -484,8 +484,7 @@ fn multisig_transaction_to_settings_change_summary() {
         .return_once(move |_| Ok(safe_info));
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| bail!("No address info"));
+        .times(0);
     mock_info_provider.expect_token_info().times(0);
 
     let expected = TransactionSummary {

--- a/src/models/converters/transactions/tests/transaction_types.rs
+++ b/src/models/converters/transactions/tests/transaction_types.rs
@@ -14,7 +14,7 @@ fn transaction_operation_not_call() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -43,7 +43,7 @@ fn transaction_data_size_and_value_greater_than_0() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -72,7 +72,7 @@ fn transaction_data_size_and_value_greater_than_0_with_address_info() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| {
             Ok(AddressInfo {
@@ -109,7 +109,7 @@ fn transaction_data_size_0_value_greater_than_0() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -137,7 +137,7 @@ fn transaction_data_size_greater_than_value_0_to_is_safe_is_settings_method() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(0);
 
     let tx = serde_json::from_str::<MultisigTransaction>(crate::json::MULTISIG_TX_SETTINGS_CHANGE)
@@ -178,7 +178,7 @@ fn transaction_data_size_greater_than_value_0_to_is_safe_is_settings_method_with
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(0);
 
     let tx = serde_json::from_str::<MultisigTransaction>(crate::json::MULTISIG_TX_SETTINGS_CHANGE)
@@ -219,7 +219,7 @@ fn transaction_data_size_greater_than_value_0_to_is_safe_is_not_settings_method(
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -252,7 +252,7 @@ fn transaction_data_decoded_is_erc20_receiver_ok_transfer_method() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -290,7 +290,7 @@ fn transaction_data_decoded_is_erc721_receiver_ok_transfer_method() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -322,7 +322,7 @@ fn transaction_data_decoded_is_erc20_receiver_not_ok_transfer_method() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("no address info"));
 
@@ -351,7 +351,7 @@ fn transaction_data_decoded_is_erc721_receiver_not_ok_transfer_method() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -391,7 +391,7 @@ fn transaction_data_decoded_is_transfer_method_receiver_ok_token_type_unknown() 
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -421,7 +421,7 @@ fn transaction_data_decoded_is_erc20_receiver_ok_token_fetch_error() {
         .times(1)
         .return_once(move |_| bail!("No token info"));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -448,7 +448,7 @@ fn cancellation_transaction() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 

--- a/src/models/converters/transactions/tests/transaction_types.rs
+++ b/src/models/converters/transactions/tests/transaction_types.rs
@@ -138,8 +138,7 @@ fn transaction_data_size_greater_than_value_0_to_is_safe_is_settings_method() {
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| bail!("No address info"));
+        .times(0);
 
     let tx = serde_json::from_str::<MultisigTransaction>(crate::json::MULTISIG_TX_SETTINGS_CHANGE)
         .unwrap();
@@ -180,23 +179,14 @@ fn transaction_data_size_greater_than_value_0_to_is_safe_is_settings_method_with
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
         .expect_address_info()
-        .times(1)
-        .return_once(move |_| {
-            Ok(AddressInfo {
-                name: "".to_string(),
-                logo_uri: None,
-            })
-        });
+        .times(0);
 
     let tx = serde_json::from_str::<MultisigTransaction>(crate::json::MULTISIG_TX_SETTINGS_CHANGE)
         .unwrap();
     let expected = TransactionInfo::SettingsChange(SettingsChange {
         settings_info: Some(SettingsInfo::AddOwner {
             owner: "0xA3DAa0d9Ae02dAA17a664c232aDa1B739eF5ae8D".to_string(),
-            owner_info: Some(AddressInfo {
-                name: "".to_string(),
-                logo_uri: None,
-            }),
+            owner_info: None,
             threshold: 2,
         }),
         data_decoded: DataDecoded {

--- a/src/models/converters/transactions/tests/transfer_type_checks.rs
+++ b/src/models/converters/transactions/tests/transfer_type_checks.rs
@@ -25,7 +25,7 @@ fn multisig_tx_check_erc721_transfer() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -128,7 +128,7 @@ fn multisig_tx_check_erc20_transfer() {
         .times(1)
         .return_once(move |_| Ok(token_info));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 
@@ -221,7 +221,7 @@ fn multisig_tx_check_ether_transfer() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -82,6 +82,17 @@ pub trait InfoProvider {
     fn token_info(&mut self, token: &str) -> ApiResult<TokenInfo>;
     fn safe_app_info(&mut self, url: &str) -> ApiResult<SafeAppInfo>;
     fn address_info(&mut self, address: &str) -> ApiResult<AddressInfo>;
+
+    fn full_address_info_search(&mut self, address: &str) -> ApiResult<AddressInfo> {
+        self.token_info(&address)
+            .map(|it| AddressInfo {
+                name: it.name,
+                logo_uri: it.logo_uri.to_owned(),
+            })
+            .or_else(|_| {
+                self.address_info(&address)
+            })
+    }
 }
 
 pub struct DefaultInfoProvider<'p> {
@@ -262,14 +273,14 @@ impl DefaultInfoProvider<'_> {
         Ok(serde_json::from_str::<Exchange>(&body)?)
     }
 
-    pub fn full_address_info_search(&mut self, address: &str) -> ApiResult<AddressInfo> {
-        self.token_info(&address)
-            .map(|it| AddressInfo {
-                name: it.name,
-                logo_uri: it.logo_uri.to_owned(),
-            })
-            .or_else(|_| {
-                self.address_info(&address)
-            })
-    }
+    // pub fn full_address_info_search(&mut self, address: &str) -> ApiResult<AddressInfo> {
+    //     self.token_info(&address)
+    //         .map(|it| AddressInfo {
+    //             name: it.name,
+    //             logo_uri: it.logo_uri.to_owned(),
+    //         })
+    //         .or_else(|_| {
+    //             self.address_info(&address)
+    //         })
+    // }
 }

--- a/src/services/tests/transactions_history.rs
+++ b/src/services/tests/transactions_history.rs
@@ -71,7 +71,7 @@ fn backend_txs_to_summary_txs_with_values() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(6)
         .returning(move |_| bail!("No address info"));
 
@@ -258,7 +258,7 @@ fn service_txs_to_tx_list_items_last_timestamp_undefined() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -314,7 +314,7 @@ fn service_txs_to_tx_list_items_last_timestamp_defined_but_different() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -371,7 +371,7 @@ fn service_txs_to_tx_list_items_last_timestamp_defined_and_same() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -422,7 +422,7 @@ fn service_txs_to_tx_list_items_date_label_berlin_timezone() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -476,7 +476,7 @@ fn service_txs_to_tx_list_items_date_label_melbourne_timezone() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -534,7 +534,7 @@ fn service_txs_to_tx_list_items_date_label_buenos_aires_timezone() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(12)
         .returning(move |_| bail!("No address info"));
 
@@ -611,7 +611,7 @@ fn peek_timestamp_and_remove_item_with_items() {
     mock_info_provider.expect_safe_info().times(0);
     mock_info_provider.expect_token_info().times(0);
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(1)
         .return_once(move |_| bail!("No address info"));
 

--- a/src/services/tests/transactions_queued.rs
+++ b/src/services/tests/transactions_queued.rs
@@ -199,7 +199,7 @@ fn process_transactions_no_conflicts_everything_queued() {
         .times(3)
         .returning(move |_| Ok(bat_token_info.clone()));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(3)
         .returning(move |_| bail!("No address info"));
 
@@ -355,7 +355,7 @@ fn process_transactions_conflicts_in_queued() {
         .times(3)
         .returning(move |_| Ok(bat_token_info.clone()));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(3)
         .returning(move |_| bail!("No address info"));
 
@@ -515,7 +515,7 @@ fn process_transactions_conflicts_in_next() {
         .times(3)
         .returning(move |_| Ok(bat_token_info.clone()));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(3)
         .returning(move |_| bail!("No address info"));
 
@@ -676,7 +676,7 @@ fn process_transactions_conflicts_in_queued_spanning_to_next_page() {
         .times(3)
         .returning(move |_| Ok(bat_token_info.clone()));
     mock_info_provider
-        .expect_address_info()
+        .expect_full_address_info_search()
         .times(3)
         .returning(move |_| bail!("No address info"));
 


### PR DESCRIPTION
Closes #292 

Changes:
- Added a default implementation method in `InfoProvider` that looks up the `tokenInfo` and `contractInfo` 
- `address_info()` function now only checks the `contracts` endpoint
- Adjusted tests and mocks accordingly
