### PR TITLE
Added config entries for request timeouts agains the core services

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -87,7 +87,7 @@ pub fn safe_app_manifest_cache_duration() -> usize {
     usize_with_default("SAFE_APP_MANIFEST_CACHE_DURATION", indefinite_timeout())
 }
 
-// REQUEST TIMEOUTS
+// REQUEST TIMEOUTS in milliseconds
 pub fn internal_client_connect_timeout() -> u64 {
     u64_with_default("INTERNAL_CLIENT_CONNECT_TIMEOUT", 1000)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,7 +105,7 @@ pub fn safe_info_request_timeout() -> u64 {
 }
 
 pub fn token_info_request_timeout() -> u64 {
-    u64_with_default("TOKEN_INFO_REQUEST_TIMEOUT", 5000)
+    u64_with_default("TOKEN_INFO_REQUEST_TIMEOUT", 30000)
 }
 
 pub fn default_request_timeout() -> u64 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -96,6 +96,22 @@ pub fn safe_app_info_request_timeout() -> u64 {
     u64_with_default("SAFE_APP_INFO_REQUEST_TIMEOUT", 3000)
 }
 
+pub fn transaction_request_timeout() -> u64 {
+    u64_with_default("TRANSACTION_REQUEST_TIMEOUT", 30000)
+}
+
+pub fn safe_info_request_timeout() -> u64 {
+    u64_with_default("SAFE_INFO_REQUEST_TIMEOUT", 10000)
+}
+
+pub fn token_info_request_timeout() -> u64 {
+    u64_with_default("TOKEN_INFO_REQUEST_TIMEOUT", 5000)
+}
+
+pub fn default_request_timeout() -> u64 {
+    u64_with_default("DEFAULT_REQUEST_TIMEOUT", 5000)
+}
+
 // ERRORS
 pub fn request_error_cache_timeout() -> usize {
     usize_with_default("REQS_ERROR_CACHE_DURATION", short_error_duration())

--- a/src/services/transactions_details.rs
+++ b/src/services/transactions_details.rs
@@ -2,6 +2,7 @@ extern crate reqwest;
 
 use crate::config::{
     base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+    transaction_request_timeout,
 };
 use crate::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::models::backend::transfers::Transfer;
@@ -29,11 +30,13 @@ pub(super) fn get_multisig_transaction_details(
         base_transaction_service_url(),
         safe_tx_hash
     );
-    let body = context.cache().request_cached(
+    let body = context.cache().request_cached_advanced(
         &context.client(),
         &url,
         request_cache_duration(),
         request_error_cache_timeout(),
+        false,
+        transaction_request_timeout(),
     )?;
     let multisig_tx: MultisigTransaction = serde_json::from_str(&body)?;
 

--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -2,6 +2,7 @@ extern crate reqwest;
 
 use crate::config::{
     base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+    transaction_request_timeout,
 };
 use crate::models::backend::transactions::Transaction;
 use crate::models::commons::{Page, PageMetadata};
@@ -124,11 +125,13 @@ fn fetch_backend_paged_txs(
         safe_address,
         page_metadata.to_url_string()
     );
-    let body = context.cache().request_cached(
+    let body = context.cache().request_cached_advanced(
         &context.client(),
         &url,
         request_cache_duration(),
         request_error_cache_timeout(),
+        false,
+        transaction_request_timeout(),
     )?;
     log::debug!("request URL: {}", &url);
     log::debug!("page_url: {:#?}", page_url);

--- a/src/services/transactions_list.rs
+++ b/src/services/transactions_list.rs
@@ -2,6 +2,7 @@ extern crate reqwest;
 
 use crate::config::{
     base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+    transaction_request_timeout,
 };
 use crate::models::backend::transactions::{CreationTransaction, Transaction};
 use crate::models::commons::Page;
@@ -25,11 +26,13 @@ pub fn get_all_transactions(
         safe_address,
         page_url.as_ref().unwrap_or(&String::new())
     );
-    let body = context.cache().request_cached(
+    let body = context.cache().request_cached_advanced(
         &context.client(),
         &url,
         request_cache_duration(),
         request_error_cache_timeout(),
+        false,
+        transaction_request_timeout(),
     )?;
     debug!("request URL: {}", &url);
     debug!("page_url: {:#?}", page_url);

--- a/src/services/transactions_queued.rs
+++ b/src/services/transactions_queued.rs
@@ -1,5 +1,6 @@
 use crate::config::{
     base_transaction_service_url, request_cache_duration, request_error_cache_timeout,
+    transaction_request_timeout,
 };
 use crate::models::backend::transactions::MultisigTransaction;
 use crate::models::commons::{Page, PageMetadata};
@@ -40,11 +41,13 @@ pub fn get_queued_transactions(
         display_trusted_only
     );
 
-    let body = context.cache().request_cached(
+    let body = context.cache().request_cached_advanced(
         &context.client(),
         &url,
         request_cache_duration(),
         request_error_cache_timeout(),
+        false,
+        transaction_request_timeout(),
     )?;
     let mut backend_transactions: Page<MultisigTransaction> = serde_json::from_str(&body)?;
 

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,4 +1,4 @@
-use crate::config::redis_scan_count;
+use crate::config::{default_request_timeout, redis_scan_count};
 use crate::utils::errors::{ApiError, ApiResult};
 use mockall::automock;
 use rocket::response::content;
@@ -111,9 +111,8 @@ pub trait CacheExt: Cache {
             Some(cached) => CachedWithCode::split(&cached).to_result(),
             None => {
                 let mut request = client.get(url);
-                if request_timeout > 0 {
-                    request = request.timeout(Duration::from_millis(request_timeout));
-                }
+                request = request.timeout(Duration::from_millis(request_timeout));
+
                 let response = request.send().map_err(|err| {
                     if cache_all_errors {
                         self.create(
@@ -164,7 +163,14 @@ pub trait CacheExt: Cache {
         cache_duration: usize,
         error_cache_duration: usize,
     ) -> ApiResult<String> {
-        self.request_cached_advanced(client, url, cache_duration, error_cache_duration, false, 0)
+        self.request_cached_advanced(
+            client,
+            url,
+            cache_duration,
+            error_cache_duration,
+            false,
+            default_request_timeout(),
+        )
     }
 }
 


### PR DESCRIPTION
Closes #340 
This PR will be addressed in #341 

- Introduced request time outs for requests against the core services
- Added specific values for certain endpoints (see #340 )
