### PR TITLE
Added Tokens variant to invalidation patterns

### DIFF
--- a/src/cache/cache_op_executors.rs
+++ b/src/cache/cache_op_executors.rs
@@ -1,6 +1,7 @@
 use crate::cache::cache_operations::{CacheResponse, InvalidationPattern, RequestCached};
 use crate::cache::inner_cache::CachedWithCode;
 use crate::cache::Cache;
+use crate::providers::info::TOKENS_KEY;
 use crate::utils::errors::{ApiError, ApiResult};
 use rocket::response::content;
 use serde::Serialize;
@@ -16,6 +17,7 @@ pub(super) fn invalidate(cache: &impl Cache, pattern: &InvalidationPattern) {
         InvalidationPattern::RequestsResponses(value) => {
             format!("{}*{}*", CACHE_REQS_RESP_PREFIX, &value)
         }
+        InvalidationPattern::Tokens => String::from(TOKENS_KEY),
     };
 
     cache.invalidate_pattern(pattern_str.as_str());

--- a/src/cache/cache_operations.rs
+++ b/src/cache/cache_operations.rs
@@ -20,6 +20,7 @@ pub struct Invalidate {
 pub enum InvalidationPattern {
     FlushAll,
     RequestsResponses(String),
+    Tokens,
 }
 
 impl Invalidate {

--- a/src/routes/hooks.rs
+++ b/src/routes/hooks.rs
@@ -22,3 +22,12 @@ pub fn flush_all(context: Context, token: String) -> ApiResult<()> {
     Invalidate::new(InvalidationPattern::FlushAll).execute(context.cache());
     Ok(())
 }
+
+#[get("/v1/flush_tokens/<token>")]
+pub fn flush_token_info(context: Context, token: String) -> ApiResult<()> {
+    if token != webhook_token() {
+        bail!("Invalid token");
+    }
+    Invalidate::new(InvalidationPattern::Tokens).execute(context.cache());
+    Ok(())
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -31,6 +31,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::propose_transaction,
         hooks::update,
         hooks::flush_all,
+        hooks::flush_token_info,
         health::health
     ]
 }


### PR DESCRIPTION
Closes #354 

Changes:
- Introduced `/v1/flush_tokens/<webhook_token>` endpoint
- Introduced `Tokens` variant as an invalidation pattern