### PR TITLE
Creation transaction is optional, can't make the whole request into a…

### DIFF
--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -51,8 +51,9 @@ pub fn get_history_transactions(
     let mut service_txs =
         backend_txs_to_summary_txs(&mut backend_txs_iter, &mut info_provider, safe_address)?;
     if backend_paged_txs.next.is_none() {
-        let creation_tx = get_creation_transaction_summary(context, safe_address)?;
-        service_txs.push(creation_tx);
+        if let Ok(creation_tx) = get_creation_transaction_summary(context, safe_address) {
+            service_txs.push(creation_tx);
+        }
     }
 
     let tx_list_items =


### PR DESCRIPTION
Closes #347 

Changes:
- Creation TX is optional in the list if the request fails for `transaction/history` (the old `transactions` endpoint already implemented this behaviour https://github.com/gnosis/safe-client-gateway/blob/7f3e17972ece74bc3ad11e2a4e8d0d54ef4660fe/src/services/transactions_list.rs#L42)