### PR TITLE
ERC721 filter for `collectibleTag` field in the `/v1/safes/<address>` endpoint

### DIFF
--- a/src/services/safes.rs
+++ b/src/services/safes.rs
@@ -35,9 +35,9 @@ pub fn get_safe_info_ex(context: &Context, safe_address: &String) -> ApiResult<S
 }
 
 fn get_last_collectible(context: &Context, safe_address: &String) -> ApiResult<i64> {
-    //TODO: Apply ERC721 filter when available in core services
     let url = format!(
         "{}/v1/safes/{}/transfers/?\
+        &erc721=true\
         &limit=1",
         base_transaction_service_url(),
         safe_address,


### PR DESCRIPTION
Closes #370 

- Added filter for only NFTs