### PR TITLE
Try to better cache multi-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build Stage
+# Build Image
 # We use a stable rust image as we will switch to nightly via the toolchain file.
 FROM rust:1.52.0-slim-buster as builder
 
@@ -27,7 +27,7 @@ ARG BUILD_NUMBER
 RUN rm -rf target/release/.fingerprint/safe-client-gateway*
 RUN cargo build --release --locked
 
-# Image Stage
+# Runtime Image
 FROM debian:buster-slim
 
 

--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -11,14 +11,36 @@ export VERSION=${description:1}
 echo "Trigger docker build and upload for version $VERSION ($BUILD_NUMBER)"
 
 if [ "$1" = "develop" -o "$1" = "main" -o "$1" = "spectrum" ]; then
-    # If image does not exist, don't use cache
-    docker pull $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$1 && \
-    docker build -t $DOCKERHUB_PROJECT -f Dockerfile --build-arg VERSION --build-arg BUILD_NUMBER . --cache-from $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$1 || \
-    docker build -t $DOCKERHUB_PROJECT -f Dockerfile --build-arg VERSION --build-arg BUILD_NUMBER .
+    cache_tag="$1"
 else
-    docker pull $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:staging && \
-    docker build -t $DOCKERHUB_PROJECT -f Dockerfile --build-arg VERSION --build-arg BUILD_NUMBER . --cache-from $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:staging || \
-    docker build -t $DOCKERHUB_PROJECT -f Dockerfile --build-arg VERSION --build-arg BUILD_NUMBER .
+    cache_tag="staging"
 fi
+
+# Load cached builder image
+docker pull $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag-builder || true
+# Rebuild builder image if required
+docker build \
+    --target builder \
+    --cache-from $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag-builder \
+    -t $DOCKERHUB_PROJECT \
+    -f Dockerfile \
+    --build-arg VERSION --build-arg BUILD_NUMBER \
+    .
+
+# Load cached runtime image
+docker pull $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag || true
+# Rebuild runtime image if required
+docker build \
+    --cache-from $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag-builder \
+    --cache-from $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag \
+    -t $DOCKERHUB_PROJECT \
+    -f Dockerfile \
+    --build-arg VERSION --build-arg BUILD_NUMBER \
+    .
+
+# Push runtime images to remote repository
 docker tag $DOCKERHUB_PROJECT $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$1
 docker push $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$1
+
+# Push builder image to remote repository for next build
+docker push $DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag-builder


### PR DESCRIPTION
Based on https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/

Note: there will be an error that the `builder` image is not available the first time we run this, but this is only a "soft" error an everything will still work.

More context:
We currently have multiple "base" images: `develop`, `main`, `spectrum` and `staging`. When building a version we were choosing between the different "base" images to reuse them for the docker cache source.

The 2 active "base" images in the client gateway repository are:
- `spectrum` used for the branch of the same name
- `staging` use for the latest commit of the `main` branch (and yes it is stupid that we also have a `main` "base" image, but something for another PR)

As we use multilayered build it actually is not enough to reuse the "base" image for the runtime as it does not contain any information about "builder" image. Therefore we now also add the creation of a "builder" image for each of the "base" images.

Namely this means we will push 2 more images to docker hub in our current setup:
- `spectrum-builder` contains the logic to compile the latest commit on the `spectrum` branch
- `staging-builder` contains the logic to compile the latest commit on the `main` branch

These builder images then can be reused in our docker CI pipeline