### PR TITLE
Partial response on `unwrap_or_default`

### DIFF
--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -146,12 +146,18 @@ pub(super) async fn backend_txs_to_summary_txs(
     let mut results = vec![];
 
     for transaction in txs {
-        if let Ok(tx_summaries) = transaction
-            .to_transaction_summary(info_provider, safe_address)
-            .await
-        {
-            results.extend(tx_summaries);
-        }
+        // if let Ok(tx_summaries) = transaction
+        //     .to_transaction_summary(info_provider, safe_address)
+        //     .await
+        // {
+        //     results.extend(tx_summaries);
+        // }
+        results.extend(
+            transaction
+                .to_transaction_summary(info_provider, safe_address)
+                .await
+                .unwrap_or_default(),
+        );
     }
 
     Ok(results)

--- a/src/services/transactions_history.rs
+++ b/src/services/transactions_history.rs
@@ -146,12 +146,12 @@ pub(super) async fn backend_txs_to_summary_txs(
     let mut results = vec![];
 
     for transaction in txs {
-        results.extend(
-            transaction
-                .to_transaction_summary(info_provider, safe_address)
-                .await
-                .unwrap_or_default(),
-        );
+        if let Ok(tx_summaries) = transaction
+            .to_transaction_summary(info_provider, safe_address)
+            .await
+        {
+            results.extend(tx_summaries);
+        }
     }
 
     Ok(results)


### PR DESCRIPTION
Closes #368 

Changes:
- We filter out errors in mapping but we return all the correct values in one page
