### PR TITLE
Domain separator for new safe version

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,6 +52,7 @@ REDIS_URL=redis://127.0.0.1:6379
 #NATIVE_COIN_DECIMALS=18
 #NATIVE_COIN_SYMBOL=ETH
 #NATIVE_COIN_NAME=Ether
+CHAIN_ID=1 # mainnet
 
 ## Exchange rate API: https://exchangeratesapi.io/
 EXCHANGE_API_BASE_URL=http://api.exchangeratesapi.io/latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ dependencies = [
  "rocket",
  "rocket_codegen",
  "rocket_contrib",
- "semver-parser 0.10.2",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2180,6 +2180,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2103,7 @@ dependencies = [
  "rocket",
  "rocket_codegen",
  "rocket_contrib",
+ "semver-parser 0.10.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2169,7 +2179,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -2177,6 +2187,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2721,6 +2740,12 @@ checksum = "42756bb9e708855de2f8a98195643dff31a97f0485d90d8467b39dc24be9e8fe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ r2d2 = "0.8.9"
 redis = { version = "0.20", features = ["r2d2"] }
 
 ethcontract-common = "0.11.1"
-ethereum-types = { version = "0.9.2", features = ["serialize"]}
+ethereum-types = { version = "0.9.2", features = ["serialize"] }
 ethabi = "12.0.0"
 
 serde = { version = "1.0", features = ["derive"] }
@@ -38,6 +38,8 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0.20"
 
 mockall = "0.9.1"
+
+semver-parser = "0.10.2"
 
 # Logging
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = "1.0.20"
 
 mockall = "0.9.1"
 
-semver-parser = "0.10.2"
+semver = "0.11.0"
 
 # Logging
 log = "0.4"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -169,5 +169,5 @@ pub fn version() -> String {
 }
 
 pub fn chain_id() -> u64 {
-    u64_with_default("CHAIN_ID", 4) // Is there a more sensible default than Rinkeby?
+    u64_with_default("CHAIN_ID", 1)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -167,3 +167,7 @@ pub fn version() -> String {
         .unwrap_or(env!("CARGO_PKG_VERSION"))
         .to_string()
 }
+
+pub fn chain_id() -> u64 {
+    u64_with_default("CHAIN_ID", 4) // Is there a more sensible default than Rinkeby?
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![deny(unused_must_use)]
 
 extern crate log;
+extern crate semver;
 
 #[macro_use]
 extern crate rocket;

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -24,6 +24,7 @@ use std::future::Future;
 use std::time::Duration;
 
 pub const TOKENS_KEY: &'static str = "dip_ti";
+pub const SAFE_V_1_3_0: &'static str = "1.3.0";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -13,9 +13,11 @@ use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use crate::utils::json::default_if_null;
 use crate::utils::urls::build_manifest_url;
+use lazy_static::lazy_static;
 use mockall::automock;
 use rocket::futures::TryFutureExt;
 use rocket::tokio::sync::Mutex;
+use semver::Version;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -24,7 +26,9 @@ use std::future::Future;
 use std::time::Duration;
 
 pub const TOKENS_KEY: &'static str = "dip_ti";
-pub const SAFE_V_1_3_0: &'static str = "1.3.0";
+lazy_static! {
+    pub static ref SAFE_V_1_3_0: Version = Version::new(1, 3, 0);
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -39,8 +39,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     .unwrap();
     let nonce = 39;
 
-    let domain_hash = domain_hash(&safe_address, true);
-    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
+    let actual = to_hex_string!(hash(safe_address, nonce, true).to_vec());
     assert_eq!(
         "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
         actual
@@ -55,8 +54,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     .unwrap();
     let nonce = 39;
 
-    let domain_hash = domain_hash(&safe_address, false);
-    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
+    let actual = to_hex_string!(hash(safe_address, nonce, false).to_vec());
     assert_eq!(
         "0xdce3bf453ed8cf84d13c76911e5d11c31501b24004b9e856d6091808067bd398",
         actual

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,3 +1,4 @@
+use crate::providers::info::SafeInfo;
 use crate::utils::transactions::{cancellation_parts_hash, domain_hash, hash};
 use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
@@ -8,9 +9,10 @@ fn domain_hash_for_safe_address() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string!(domain_hash(&safe_address, false).to_vec());
+    let actual =
+        to_hex_string!(domain_hash(&safe_address, build_safe_info("1.3.0".to_string())).to_vec());
     assert_eq!(
-        "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
+        "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
         actual
     );
 }
@@ -21,7 +23,8 @@ fn domain_hash_for_safe_address_legacy() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string!(domain_hash(&safe_address, true).to_vec());
+    let actual =
+        to_hex_string!(domain_hash(&safe_address, build_safe_info("1.1.1".to_string())).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
         actual
@@ -29,17 +32,33 @@ fn domain_hash_for_safe_address_legacy() {
 }
 
 #[test]
-fn safe_tx_hash_for_safe_address_cancellation_tx() {
+fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
     let nonce = 39;
 
-    let domain_hash = domain_hash(&safe_address, true);
+    let domain_hash = domain_hash(&safe_address, build_safe_info("1.1.1".to_string()));
     let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
+        actual
+    );
+}
+
+#[test]
+fn safe_tx_hash_for_safe_address_cancellation_tx() {
+    let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
+        "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f".to_string(),
+    ))
+    .unwrap();
+    let nonce = 39;
+
+    let domain_hash = domain_hash(&safe_address, build_safe_info("1.3.0".to_string()));
+    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
+    assert_eq!(
+        "0xdce3bf453ed8cf84d13c76911e5d11c31501b24004b9e856d6091808067bd398",
         actual
     );
 }
@@ -65,4 +84,17 @@ fn empty_data_keccak() {
         to_hex_string!(keccak256(vec![])),
         "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
     );
+}
+
+fn build_safe_info(version: String) -> Option<SafeInfo> {
+    Some(SafeInfo {
+        address: "".to_string(),
+        nonce: 0,
+        threshold: 0,
+        owners: vec![],
+        master_copy: "".to_string(),
+        modules: None,
+        fallback_handler: None,
+        version: Some(version),
+    })
 }

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -36,7 +36,8 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     .unwrap();
     let nonce = 39;
 
-    let actual = to_hex_string!(hash(safe_address, nonce).to_vec());
+    let domain_hash = domain_hash(&safe_address, true);
+    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
         actual

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,5 +1,7 @@
 use crate::providers::info::SafeInfo;
-use crate::utils::transactions::{cancellation_parts_hash, domain_hash, hash};
+use crate::utils::transactions::{
+    cancellation_parts_hash, domain_hash, hash, is_legacy_domain_separator,
+};
 use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
 
@@ -9,8 +11,7 @@ fn domain_hash_for_safe_address() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual =
-        to_hex_string!(domain_hash(&safe_address, build_safe_info("1.3.0".to_string())).to_vec());
+    let actual = to_hex_string!(domain_hash(&safe_address, false).to_vec());
     assert_eq!(
         "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
         actual
@@ -23,8 +24,7 @@ fn domain_hash_for_safe_address_legacy() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual =
-        to_hex_string!(domain_hash(&safe_address, build_safe_info("1.1.1".to_string())).to_vec());
+    let actual = to_hex_string!(domain_hash(&safe_address, true).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
         actual
@@ -39,7 +39,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     .unwrap();
     let nonce = 39;
 
-    let domain_hash = domain_hash(&safe_address, build_safe_info("1.1.1".to_string()));
+    let domain_hash = domain_hash(&safe_address, true);
     let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
@@ -55,7 +55,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     .unwrap();
     let nonce = 39;
 
-    let domain_hash = domain_hash(&safe_address, build_safe_info("1.3.0".to_string()));
+    let domain_hash = domain_hash(&safe_address, false);
     let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0xdce3bf453ed8cf84d13c76911e5d11c31501b24004b9e856d6091808067bd398",
@@ -84,6 +84,20 @@ fn empty_data_keccak() {
         to_hex_string!(keccak256(vec![])),
         "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
     );
+}
+
+#[test]
+fn is_legacy_domain_separator_v130() {
+    let safe_info = build_safe_info("1.3.0".to_string());
+
+    assert_eq!(false, is_legacy_domain_separator(safe_info));
+}
+
+#[test]
+fn is_legacy_domain_separator_legacy() {
+    let safe_info = build_safe_info("1.1.1".to_string());
+
+    assert_eq!(true, is_legacy_domain_separator(safe_info));
 }
 
 fn build_safe_info(version: String) -> Option<SafeInfo> {

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -8,7 +8,20 @@ fn domain_hash_for_safe_address() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string!(domain_hash(&safe_address).to_vec());
+    let actual = to_hex_string!(domain_hash(&safe_address, false).to_vec());
+    assert_eq!(
+        "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
+        actual
+    );
+}
+
+#[test]
+fn domain_hash_for_safe_address_legacy() {
+    let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
+        "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
+    ))
+    .unwrap();
+    let actual = to_hex_string!(domain_hash(&safe_address, true).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
         actual

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,6 +1,6 @@
 use crate::providers::info::SafeInfo;
 use crate::utils::transactions::{
-    cancellation_parts_hash, domain_hash, hash, is_legacy_domain_separator,
+    cancellation_parts_hash, domain_hash_v100, domain_hash_v130, hash, use_legacy_domain_separator,
 };
 use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
@@ -11,7 +11,7 @@ fn domain_hash_for_safe_address() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string!(domain_hash(&safe_address, false).to_vec());
+    let actual = to_hex_string!(domain_hash_v130(&safe_address, 4).to_vec()); // Rinkeby
     assert_eq!(
         "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
         actual
@@ -24,7 +24,7 @@ fn domain_hash_for_safe_address_legacy() {
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
     .unwrap();
-    let actual = to_hex_string!(domain_hash(&safe_address, true).to_vec());
+    let actual = to_hex_string!(domain_hash_v100(&safe_address).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
         actual
@@ -38,8 +38,9 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     ))
     .unwrap();
     let nonce = 39;
+    let domain_hash = domain_hash_v100(&safe_address);
 
-    let actual = to_hex_string!(hash(safe_address, nonce, true).to_vec());
+    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0x89067bfebe450e45c02dd97e3cc9bd1656d49ebb8a17819829eab9c5dc575c27",
         actual
@@ -53,8 +54,9 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     ))
     .unwrap();
     let nonce = 39;
+    let domain_hash = domain_hash_v130(&safe_address, 4); // Rinkeby
 
-    let actual = to_hex_string!(hash(safe_address, nonce, false).to_vec());
+    let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(
         "0xdce3bf453ed8cf84d13c76911e5d11c31501b24004b9e856d6091808067bd398",
         actual
@@ -85,17 +87,17 @@ fn empty_data_keccak() {
 }
 
 #[test]
-fn is_legacy_domain_separator_v130() {
+fn use_legacy_domain_separator_v130() {
     let safe_info = build_safe_info("1.3.0".to_string());
 
-    assert_eq!(false, is_legacy_domain_separator(safe_info));
+    assert_eq!(false, use_legacy_domain_separator(safe_info));
 }
 
 #[test]
-fn is_legacy_domain_separator_legacy() {
+fn use_legacy_domain_separator_legacy() {
     let safe_info = build_safe_info("1.1.1".to_string());
 
-    assert_eq!(true, is_legacy_domain_separator(safe_info));
+    assert_eq!(true, use_legacy_domain_separator(safe_info));
 }
 
 fn build_safe_info(version: String) -> Option<SafeInfo> {

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -30,8 +30,7 @@ pub async fn fetch_rejections(
     let safe_address: Address =
         serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
 
-    let safe_tx_hash =
-        to_hex_string!(hash(safe_address, nonce, domain_hash(&safe_address, is_legacy)).to_vec());
+    let safe_tx_hash = to_hex_string!(hash(safe_address, nonce, is_legacy).to_vec());
 
     let multisig_tx = fetch_cancellation_tx(context, safe_tx_hash).await;
     multisig_tx
@@ -47,9 +46,10 @@ pub async fn fetch_rejections(
         .flatten()
 }
 
-pub(super) fn hash(safe_address: Address, nonce: u64, domain_hash: [u8; 32]) -> [u8; 32] {
+pub(super) fn hash(safe_address: Address, nonce: u64, is_legacy: bool) -> [u8; 32] {
     let erc_191_byte = u8::from_str_radix(ERC191_BYTE, 16).unwrap();
     let erc_191_version = u8::from_str_radix(ERC191_VERSION, 16).unwrap();
+    let domain_hash = domain_hash(&safe_address, is_legacy);
 
     let mut encoded = ethabi::encode(&[
         ethabi::Token::Uint(Uint::from(domain_hash)),

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -1,15 +1,17 @@
 use crate::cache::cache_operations::RequestCached;
 use crate::config::{base_transaction_service_url, chain_id, transaction_request_timeout};
 use crate::models::backend::transactions::MultisigTransaction;
-use crate::providers::info::{DefaultInfoProvider, InfoProvider, SAFE_V_1_3_0};
+use crate::providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo, SAFE_V_1_3_0};
 use crate::utils::context::Context;
 use ethabi::Uint;
 use ethcontract_common::hash::keccak256;
 use ethereum_types::{Address, H256};
 use semver::Version;
 
-pub const DOMAIN_SEPARATOR_TYPEHASH: &'static str =
+pub const DOMAIN_SEPARATOR_TYPEHASH_LEGACY: &'static str =
     "0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749";
+pub const DOMAIN_SEPARATOR_TYPEHASH: &'static str =
+    "0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218";
 pub const SAFE_TX_TYPEHASH: &'static str =
     "0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8";
 
@@ -24,22 +26,11 @@ pub async fn fetch_rejections(
     let info_provider = DefaultInfoProvider::new(&context);
     let safe_info = info_provider.safe_info(safe_address).await.ok();
 
-    let version = safe_info
-        .as_ref()
-        .and_then(|safe_info| safe_info.version.as_ref().map(|it| Version::parse(it).ok()))
-        .flatten();
-
     let safe_address: Address =
         serde_json::from_value(serde_json::value::Value::String(safe_address.to_string())).unwrap();
 
-    let is_legacy = if let Some(version) = version {
-        version <= Version::parse(SAFE_V_1_3_0).unwrap_or(Version::new(1, 3, 0))
-    } else {
-        true
-    };
-
     let safe_tx_hash =
-        to_hex_string!(hash(safe_address, nonce, domain_hash(&safe_address, is_legacy)).to_vec());
+        to_hex_string!(hash(safe_address, nonce, domain_hash(&safe_address, safe_info)).to_vec());
 
     let multisig_tx = fetch_cancellation_tx(context, safe_tx_hash).await;
     multisig_tx
@@ -69,9 +60,16 @@ pub(super) fn hash(safe_address: Address, nonce: u64, domain_hash: [u8; 32]) -> 
     keccak256(encoded)
 }
 
-pub(super) fn domain_hash(safe_address: &Address, is_legacy: bool) -> [u8; 32] {
+pub(super) fn domain_hash(safe_address: &Address, safe_info: Option<SafeInfo>) -> [u8; 32] {
+    let is_legacy = is_legacy_domain_separator(safe_info);
+    let domain_separator_typehash = if is_legacy {
+        DOMAIN_SEPARATOR_TYPEHASH_LEGACY
+    } else {
+        DOMAIN_SEPARATOR_TYPEHASH
+    };
+
     let domain_separator: H256 =
-        serde_json::from_value(serde_json::Value::String(DOMAIN_SEPARATOR_TYPEHASH.into()))
+        serde_json::from_value(serde_json::Value::String(domain_separator_typehash.into()))
             .unwrap();
 
     let encoded = if is_legacy {
@@ -109,6 +107,19 @@ pub(super) fn cancellation_parts_hash(safe_address: &Address, nonce: u64) -> [u8
     ]);
 
     keccak256(encoded_parts)
+}
+
+pub(super) fn is_legacy_domain_separator(safe_info: Option<SafeInfo>) -> bool {
+    let version = safe_info
+        .as_ref()
+        .and_then(|safe_info| safe_info.version.as_ref().map(|it| Version::parse(it).ok()))
+        .flatten();
+
+    if let Some(version) = version {
+        version < Version::parse(SAFE_V_1_3_0).unwrap_or(Version::new(1, 3, 0))
+    } else {
+        true
+    }
 }
 
 // We silently fail if the cancellation transaction is not found


### PR DESCRIPTION
Closes #348 

Changes:
- Added checking of safe version for calculating the `domain_separator`
- I still need to find real world data for `domain_hash_for_safe_address` test