### PR TITLE
Pinned `grcov` to v0.8.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,11 +68,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cargo/bin/
-          key: ${{ runner.os }}-grcov-latest
+          key: ${{ runner.os }}-grcov-v080
 
       - name: Fetch grcov
         if: steps.grcov-cache.outputs.cache-hit != 'true'
-        run: curl --location https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+        run: curl --location https://github.com/mozilla/grcov/releases/download/v0.8.0/grcov-tcmalloc-linux-x86_64.tar.bz2 | tar jxf -
 
       - name: Run grcov
         id: coverage
@@ -116,7 +116,3 @@ jobs:
       - name: Deploy develop # unused
         if: github.ref == 'refs/heads/develop'
         run: bash scripts/deploy_docker.sh develop
-
-      - name: Deploy spectrum
-        if: github.ref == 'refs/heads/spectrum'
-        run: bash scripts/deploy_docker.sh spectrum

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache grcov
         id: grcov-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.5
         with:
           path: /home/runner/.cargo/bin/
           key: ${{ runner.os }}-grcov-v080

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Fetch grcov
         if: steps.grcov-cache.outputs.cache-hit != 'true'
-        run: curl --location https://github.com/mozilla/grcov/releases/download/v0.8.0/grcov-tcmalloc-linux-x86_64.tar.bz2 | tar jxf -
+        run: curl --location https://github.com/mozilla/grcov/releases/download/v0.8.0/grcov-linux-x86_64.tar.bz2 | tar jxf -
 
       - name: Run grcov
         id: coverage

--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -10,7 +10,7 @@ export VERSION=${description:1}
 
 echo "Trigger docker build and upload for version $VERSION ($BUILD_NUMBER)"
 
-if [ "$1" = "develop" -o "$1" = "main" -o "$1" = "spectrum" ]; then
+if [ "$1" = "develop" -o "$1" = "main" ]; then
     cache_tag="$1"
 else
     cache_tag="staging"


### PR DESCRIPTION
Closes #369 

Changes:
- Pinned version of grcov to `v0.8.0`
- Removed any `spectrum` associated branch in the deployment script