### PR TITLE
Refactor `safeTxHash` calculation

### DIFF
--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -12,7 +12,7 @@ fn domain_hash_for_safe_address() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-        .unwrap();
+    .unwrap();
     let actual = to_hex_string!(domain_hash_v130(&safe_address).to_vec());
     assert_eq!(
         "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
@@ -25,7 +25,7 @@ fn domain_hash_for_safe_address_legacy() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-        .unwrap();
+    .unwrap();
     let actual = to_hex_string!(domain_hash_v100(&safe_address).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
@@ -38,7 +38,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-        .unwrap();
+    .unwrap();
     let nonce = 39;
     let domain_hash = domain_hash_v100(&safe_address);
 
@@ -55,7 +55,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f".to_string(),
     ))
-        .unwrap();
+    .unwrap();
     let nonce = 39;
     let domain_hash = domain_hash_v130(&safe_address);
 
@@ -71,7 +71,7 @@ fn parts_hash_for_cancellation() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-        .unwrap();
+    .unwrap();
     let nonce = 39;
 
     let actual = cancellation_parts_hash(&safe_address, nonce);

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -4,14 +4,16 @@ use crate::utils::transactions::{
 use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
 use semver::Version;
+use std::env;
 
 #[test]
 fn domain_hash_for_safe_address() {
+    env::set_var("CHAIN_ID", "4"); // Rinkeby
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
         .unwrap();
-    let actual = to_hex_string!(domain_hash_v130(&safe_address, 4).to_vec()); // Rinkeby
+    let actual = to_hex_string!(domain_hash_v130(&safe_address).to_vec());
     assert_eq!(
         "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
         actual
@@ -49,12 +51,13 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
 
 #[test]
 fn safe_tx_hash_for_safe_address_cancellation_tx() {
+    env::set_var("CHAIN_ID", "4"); // Rinkeby
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f".to_string(),
     ))
         .unwrap();
     let nonce = 39;
-    let domain_hash = domain_hash_v130(&safe_address, 4); // Rinkeby
+    let domain_hash = domain_hash_v130(&safe_address);
 
     let actual = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
     assert_eq!(

--- a/src/utils/tests/transactions.rs
+++ b/src/utils/tests/transactions.rs
@@ -1,16 +1,16 @@
-use crate::providers::info::SafeInfo;
 use crate::utils::transactions::{
     cancellation_parts_hash, domain_hash_v100, domain_hash_v130, hash, use_legacy_domain_separator,
 };
 use ethcontract_common::hash::keccak256;
 use ethereum_types::Address;
+use semver::Version;
 
 #[test]
 fn domain_hash_for_safe_address() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-    .unwrap();
+        .unwrap();
     let actual = to_hex_string!(domain_hash_v130(&safe_address, 4).to_vec()); // Rinkeby
     assert_eq!(
         "0x0d56532a2a780ffd32b2c3d85d0f8a7b2fc13df0576c006e2aaa47eb66cf71c9",
@@ -23,7 +23,7 @@ fn domain_hash_for_safe_address_legacy() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-    .unwrap();
+        .unwrap();
     let actual = to_hex_string!(domain_hash_v100(&safe_address).to_vec());
     assert_eq!(
         "0x6dda5da6f3b6225311946ab4732b5658018db6dc890378fbdb529d8e9832762a",
@@ -36,7 +36,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx_legacy() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-    .unwrap();
+        .unwrap();
     let nonce = 39;
     let domain_hash = domain_hash_v100(&safe_address);
 
@@ -52,7 +52,7 @@ fn safe_tx_hash_for_safe_address_cancellation_tx() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f".to_string(),
     ))
-    .unwrap();
+        .unwrap();
     let nonce = 39;
     let domain_hash = domain_hash_v130(&safe_address, 4); // Rinkeby
 
@@ -68,7 +68,7 @@ fn parts_hash_for_cancellation() {
     let safe_address: Address = serde_json::from_value(serde_json::value::Value::String(
         "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67".to_string(),
     ))
-    .unwrap();
+        .unwrap();
     let nonce = 39;
 
     let actual = cancellation_parts_hash(&safe_address, nonce);
@@ -88,27 +88,14 @@ fn empty_data_keccak() {
 
 #[test]
 fn use_legacy_domain_separator_v130() {
-    let safe_info = build_safe_info("1.3.0".to_string());
+    let version = Version::parse("1.3.0").ok();
 
-    assert_eq!(false, use_legacy_domain_separator(safe_info));
+    assert_eq!(false, use_legacy_domain_separator(version));
 }
 
 #[test]
 fn use_legacy_domain_separator_legacy() {
-    let safe_info = build_safe_info("1.1.1".to_string());
+    let version = Version::parse("1.1.1").ok();
 
-    assert_eq!(true, use_legacy_domain_separator(safe_info));
-}
-
-fn build_safe_info(version: String) -> Option<SafeInfo> {
-    Some(SafeInfo {
-        address: "".to_string(),
-        nonce: 0,
-        threshold: 0,
-        owners: vec![],
-        master_copy: "".to_string(),
-        modules: None,
-        fallback_handler: None,
-        version: Some(version),
-    })
+    assert_eq!(true, use_legacy_domain_separator(version));
 }

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -25,8 +25,7 @@ pub async fn fetch_rejections(
     nonce: u64,
 ) -> Option<Vec<String>> {
     let info_provider = DefaultInfoProvider::new(&context);
-    let safe_info = info_provider.safe_info(safe_address).await.ok();
-    let version = safe_info
+    let version = info_provider.safe_info(safe_address).await.ok()
         .as_ref()
         .and_then(|safe_info| safe_info.version.as_ref().map(|it| Version::parse(it).ok()))
         .flatten();

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -35,7 +35,7 @@ pub async fn fetch_rejections(
     let domain_hash = if is_legacy {
         domain_hash_v100(&safe_address)
     } else {
-        domain_hash_v130(&safe_address, chain_id())
+        domain_hash_v130(&safe_address)
     };
 
     let safe_tx_hash = to_hex_string!(hash(safe_address, nonce, domain_hash).to_vec());
@@ -68,14 +68,14 @@ pub(super) fn hash(safe_address: Address, nonce: u64, domain_hash: [u8; 32]) -> 
     keccak256(encoded)
 }
 
-pub(super) fn domain_hash_v130(safe_address: &Address, chain_id: u64) -> [u8; 32] {
+pub(super) fn domain_hash_v130(safe_address: &Address) -> [u8; 32] {
     let domain_separator: H256 =
         serde_json::from_value(serde_json::Value::String(DOMAIN_SEPARATOR_TYPEHASH.into()))
             .unwrap();
 
     let encoded = ethabi::encode(&[
         ethabi::Token::Uint(Uint::from(domain_separator.0)),
-        ethabi::Token::Uint(Uint::from(chain_id)),
+        ethabi::Token::Uint(Uint::from(chain_id())),
         ethabi::Token::Address(Address::from(safe_address.0)),
     ]);
     keccak256(encoded)

--- a/src/utils/transactions.rs
+++ b/src/utils/transactions.rs
@@ -25,7 +25,10 @@ pub async fn fetch_rejections(
     nonce: u64,
 ) -> Option<Vec<String>> {
     let info_provider = DefaultInfoProvider::new(&context);
-    let version = info_provider.safe_info(safe_address).await.ok()
+    let version = info_provider
+        .safe_info(safe_address)
+        .await
+        .ok()
         .as_ref()
         .and_then(|safe_info| safe_info.version.as_ref().map(|it| Version::parse(it).ok()))
         .flatten();
@@ -85,7 +88,7 @@ pub(super) fn domain_hash_v100(safe_address: &Address) -> [u8; 32] {
     let domain_separator: H256 = serde_json::from_value(serde_json::Value::String(
         DOMAIN_SEPARATOR_TYPEHASH_LEGACY.into(),
     ))
-        .unwrap();
+    .unwrap();
 
     let encoded = ethabi::encode(&[
         ethabi::Token::Uint(Uint::from(domain_separator.0)),


### PR DESCRIPTION
Closes #399 

Changes:
- Moved down `get_chain_id` call, setting the `env` var in the test, thus validating the name
- Passed only the version for `use_legacy_domain_separator` method
