### PR TITLE
Chain Endpoints

### DIFF
--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -11,7 +11,7 @@ use rocket::response::content;
  * `/v1/chains/<chain_id>/` <br/>
  * Returns [ChainInfo](crate::models::chains::ChainInfo)
  *
- * # Balances
+ * # Chains
  *
  * This endpoint returns the [ChainInfo](crate::models::chains::ChainInfo) for a given `chainId`
  *
@@ -36,7 +36,7 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * `/v1/chains/` <br/>
  * Returns a [Page](crate::models::commons::Page) of [ChainInfo](crate::models::chains::ChainInfo)
  *
- * # Balances
+ * # Chains
  *
  * Returns a paginated list of all the supported [ChainInfo](crate::models::chains::ChainInfo)
  *

--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -1,0 +1,59 @@
+use crate::cache::cache_operations::{CacheResponse, RequestCached};
+use crate::config::{
+    base_config_service_url, chain_info_cache_duration, chain_info_request_timeout,
+};
+use crate::providers::info::{DefaultInfoProvider, InfoProvider};
+use crate::utils::context::Context;
+use crate::utils::errors::ApiResult;
+use rocket::response::content;
+
+/**
+ * `/v1/chains/<chain_id>/` <br/>
+ * Returns [ChainInfo](crate::models::chains::ChainInfo)
+ *
+ * # Balances
+ *
+ * This endpoint returns the [ChainInfo](crate::models::chains::ChainInfo) for a given `chainId`
+ *
+ * ## Path
+ *
+ * - `/v1/chains/<chain_id>/`returns the `ChainInfo` for `<chain_id>`
+ *
+ */
+#[get("/v1/chains/<chain_id>")]
+pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<content::Json<String>> {
+    CacheResponse::new(context.uri())
+        .duration(chain_info_cache_duration())
+        .resp_generator(async || {
+            let info_provider = DefaultInfoProvider::new(&context);
+            info_provider.chain_info(&chain_id).await
+        })
+        .execute(context.cache())
+        .await
+}
+
+/**
+ * `/v1/chains/` <br/>
+ * Returns a [Page](crate::models::commons::Page) of [ChainInfo](crate::models::chains::ChainInfo)
+ *
+ * # Balances
+ *
+ * Returns a paginated list of all the supported [ChainInfo](crate::models::chains::ChainInfo)
+ *
+ * ## Path
+ *
+ * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
+ *
+ */
+#[get("/v1/chains")]
+pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
+    let url = format!("{}/v1/chains", base_config_service_url(),);
+
+    Ok(content::Json(
+        RequestCached::new(url)
+            .request_timeout(chain_info_request_timeout())
+            .cache_duration(chain_info_cache_duration())
+            .execute(context.client(), context.cache())
+            .await?,
+    ))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -9,6 +9,8 @@ use rocket::Route;
 pub mod about;
 /// # Balance endpoints
 pub mod balances;
+/// # Chain endpoints
+pub mod chains;
 /// # Collectibles endpoint
 pub mod collectibles;
 #[doc(hidden)]
@@ -17,7 +19,6 @@ pub mod health;
 pub mod hooks;
 /// # Safe endpoints
 pub mod safes;
-
 /// # Transactions endpoints
 ///
 /// As presented by the endpoints in this service, we are taking in the types returned by the [transaction service](https://github.com/gnosis/safe-transaction-service-example), which to this data are `Multisig`, `Module` and `Ethereum` transaction types.
@@ -34,6 +35,8 @@ pub fn active_routes() -> Vec<Route> {
         about::redis,
         balances::get_balances,
         balances::get_supported_fiat,
+        chains::get_chain,
+        chains::get_chains,
         collectibles::get_collectibles,
         safes::get_safe_info,
         transactions::get_transactions,


### PR DESCRIPTION
Closes #422 

- Added a forward endpoint for `/v1/chains`
- Added an endpoint returning the `ChainInfo` of a single chain requiring the the `chain_id` as input