### PR TITLE
Use ChainInfo for pagination

### DIFF
--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -1,8 +1,7 @@
-use crate::cache::cache_operations::{CacheResponse, RequestCached};
-use crate::config::{
-    base_config_service_url, chain_info_cache_duration, chain_info_request_timeout,
-};
+use crate::cache::cache_operations::CacheResponse;
+use crate::config::chain_info_cache_duration;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
+use crate::services::chains::get_chains_paginated;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
@@ -45,19 +44,14 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains")]
-pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
-    let mut url = reqwest::Url::parse(base_config_service_url().as_str())
-        .expect("Bad base config service url");
-    url.path_segments_mut()
-        .expect("Cannot add chain_id to path")
-        .extend(["v1", "chains"]);
-
-    Ok(content::Json(
-        RequestCached::new(url.to_string())
-            .request_timeout(chain_info_request_timeout())
-            .cache_duration(chain_info_cache_duration())
-            .execute(context.client(), context.cache())
-            .await?,
-    ))
+#[get("/v1/chains?<limit>&<offset>")]
+pub async fn get_chains(
+    context: Context<'_>,
+    limit: Option<String>,
+    offset: Option<String>,
+) -> ApiResult<content::Json<String>> {
+    CacheResponse::new(context.uri())
+        .resp_generator(|| get_chains_paginated(&context, limit.as_ref(), offset.as_ref()))
+        .execute(context.cache())
+        .await
 }

--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -44,14 +44,10 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains?<limit>&<offset>")]
-pub async fn get_chains(
-    context: Context<'_>,
-    limit: Option<String>,
-    offset: Option<String>,
-) -> ApiResult<content::Json<String>> {
+#[get("/v1/chains")]
+pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
     CacheResponse::new(context.uri())
-        .resp_generator(|| get_chains_paginated(&context, limit.as_ref(), offset.as_ref()))
+        .resp_generator(|| get_chains_paginated(&context))
         .execute(context.cache())
         .await
 }

--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -44,10 +44,13 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains")]
-pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
+#[get("/v1/chains?<limit>")]
+pub async fn get_chains(
+    context: Context<'_>,
+    limit: Option<String>,
+) -> ApiResult<content::Json<String>> {
     CacheResponse::new(context.uri())
-        .resp_generator(|| get_chains_paginated(&context))
+        .resp_generator(|| get_chains_paginated(&context, &limit))
         .execute(context.cache())
         .await
 }

--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -44,13 +44,10 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains?<limit>")]
-pub async fn get_chains(
-    context: Context<'_>,
-    limit: Option<String>,
-) -> ApiResult<content::Json<String>> {
+#[get("/v1/chains")]
+pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
     CacheResponse::new(context.uri())
-        .resp_generator(|| get_chains_paginated(&context, &limit))
+        .resp_generator(|| get_chains_paginated(&context))
         .execute(context.cache())
         .await
 }

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -7,18 +7,10 @@ use crate::models::commons::Page;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use reqwest::Url;
-use std::collections::HashMap;
 
-pub async fn get_chains_paginated(
-    context: &Context<'_>,
-    limit: &Option<String>,
-) -> ApiResult<Page<ChainInfo>> {
-    let mut queries: HashMap<&str, String> = HashMap::new();
-    if let Some(limit) = limit {
-        queries.insert("limit", limit.to_string());
-    }
-    let mut url = Url::parse_with_params(base_config_service_url().as_str(), queries)
-        .expect("Bad base config service url");
+pub async fn get_chains_paginated(context: &Context<'_>) -> ApiResult<Page<ChainInfo>> {
+    let mut url =
+        Url::parse(base_config_service_url().as_str()).expect("Bad base config service url");
     url.path_segments_mut()
         .expect("Cannot add chain_id to path")
         .extend(["v1", "chains"]);

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -8,9 +8,16 @@ use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use reqwest::Url;
 
-pub async fn get_chains_paginated(context: &Context<'_>) -> ApiResult<Page<ChainInfo>> {
-    let mut url =
-        Url::parse(base_config_service_url().as_str()).expect("Bad base config service url");
+pub async fn get_chains_paginated(
+    context: &Context<'_>,
+    limit: &Option<String>,
+) -> ApiResult<Page<ChainInfo>> {
+    let mut queries: Vec<(String, String)> = vec![];
+    if let Some(limit) = limit {
+        queries.push(("limit".to_string(), limit.to_string()))
+    }
+    let mut url = Url::parse_with_params(base_config_service_url().as_str(), queries)
+        .expect("Bad base config service url");
     url.path_segments_mut()
         .expect("Cannot add chain_id to path")
         .extend(["v1", "chains"]);

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -6,21 +6,11 @@ use crate::models::chains::ChainInfo;
 use crate::models::commons::Page;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
+use reqwest::Url;
 
-pub async fn get_chains_paginated(
-    context: &Context<'_>,
-    limit: Option<&String>,
-    offset: Option<&String>,
-) -> ApiResult<Page<ChainInfo>> {
-    let mut queries: Vec<(String, String)> = vec![];
-    if let Some(limit) = limit {
-        queries.push(("limit".to_string(), limit.to_owned()))
-    }
-    if let Some(offset) = offset {
-        queries.push(("offset".to_string(), offset.to_owned()))
-    }
-    let mut url = reqwest::Url::parse_with_params(base_config_service_url().as_str(), queries)
-        .expect("Bad base config service url");
+pub async fn get_chains_paginated(context: &Context<'_>) -> ApiResult<Page<ChainInfo>> {
+    let mut url =
+        Url::parse(base_config_service_url().as_str()).expect("Bad base config service url");
     url.path_segments_mut()
         .expect("Cannot add chain_id to path")
         .extend(["v1", "chains"]);

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -1,0 +1,36 @@
+use crate::cache::cache_operations::RequestCached;
+use crate::config::{
+    base_config_service_url, chain_info_cache_duration, chain_info_request_timeout,
+};
+use crate::models::chains::ChainInfo;
+use crate::models::commons::Page;
+use crate::utils::context::Context;
+use crate::utils::errors::ApiResult;
+
+pub async fn get_chains_paginated(
+    context: &Context<'_>,
+    limit: Option<&String>,
+    offset: Option<&String>,
+) -> ApiResult<Page<ChainInfo>> {
+    let mut queries: Vec<(String, String)> = vec![];
+    if let Some(limit) = limit {
+        queries.push(("limit".to_string(), limit.to_owned()))
+    }
+    if let Some(offset) = offset {
+        queries.push(("offset".to_string(), offset.to_owned()))
+    }
+    let mut url = reqwest::Url::parse_with_params(base_config_service_url().as_str(), queries)
+        .expect("Bad base config service url");
+    url.path_segments_mut()
+        .expect("Cannot add chain_id to path")
+        .extend(["v1", "chains"]);
+
+    let body = RequestCached::new(url.to_string())
+        .request_timeout(chain_info_request_timeout())
+        .cache_duration(chain_info_cache_duration())
+        .execute(context.client(), context.cache())
+        .await?;
+
+    let page: Page<ChainInfo> = serde_json::from_str::<Page<ChainInfo>>(&body)?;
+    Ok(page)
+}

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -7,14 +7,15 @@ use crate::models::commons::Page;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use reqwest::Url;
+use std::collections::HashMap;
 
 pub async fn get_chains_paginated(
     context: &Context<'_>,
     limit: &Option<String>,
 ) -> ApiResult<Page<ChainInfo>> {
-    let mut queries: Vec<(String, String)> = vec![];
+    let mut queries: HashMap<&str, String> = HashMap::new();
     if let Some(limit) = limit {
-        queries.push(("limit".to_string(), limit.to_string()))
+        queries.insert("limit", limit.to_string());
     }
     let mut url = Url::parse_with_params(base_config_service_url().as_str(), queries)
         .expect("Bad base config service url");

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 
 pub mod about;
 pub mod balances;
+pub mod chains;
 pub mod collectibles;
 pub mod hooks;
 pub mod safes;


### PR DESCRIPTION
Closes #445

- `/v1/chains` now uses `ChainInfo` in order to parse and validate the returned payload by the Safe Config Service