### PR TITLE
Remove Native Coin config helpers

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -154,22 +154,6 @@ pub fn build_number() -> Option<String> {
     option_env!("BUILD_NUMBER").map(|it| it.to_string())
 }
 
-pub fn native_coin_decimals() -> u64 {
-    u64_with_default("NATIVE_COIN_DECIMALS", 18)
-}
-
-pub fn native_coin_symbol() -> String {
-    env::var("NATIVE_COIN_SYMBOL")
-        .unwrap_or(String::from("ETH"))
-        .to_string()
-}
-
-pub fn native_coin_name() -> String {
-    env::var("NATIVE_COIN_NAME")
-        .unwrap_or(String::from("Ether"))
-        .to_string()
-}
-
 pub fn version() -> String {
     option_env!("VERSION")
         .unwrap_or(env!("CARGO_PKG_VERSION"))

--- a/src/models/converters/balances.rs
+++ b/src/models/converters/balances.rs
@@ -1,10 +1,10 @@
-use crate::config::{native_coin_decimals, native_coin_name, native_coin_symbol};
 use crate::models::backend::balances::Balance as BalanceDto;
+use crate::models::chains::NativeCurrency;
 use crate::models::service::balances::Balance;
 use crate::providers::info::{TokenInfo, TokenType};
 
 impl BalanceDto {
-    pub fn to_balance(&self, usd_to_fiat: f64) -> Balance {
+    pub fn to_balance(&self, usd_to_fiat: f64, native_coin: &NativeCurrency) -> Balance {
         let fiat_conversion = self.fiat_conversion.parse::<f64>().unwrap_or(0.0) * usd_to_fiat;
         let fiat_balance = self.fiat_balance.parse::<f64>().unwrap_or(0.0) * usd_to_fiat;
         let token_type = self
@@ -23,17 +23,17 @@ impl BalanceDto {
                     .token
                     .as_ref()
                     .map(|it| it.decimals)
-                    .unwrap_or(native_coin_decimals()),
+                    .unwrap_or(native_coin.decimals),
                 symbol: self
                     .token
                     .as_ref()
                     .map(|it| it.symbol.to_string())
-                    .unwrap_or(native_coin_symbol()),
+                    .unwrap_or(native_coin.symbol.to_string()),
                 name: self
                     .token
                     .as_ref()
                     .map(|it| it.name.to_string())
-                    .unwrap_or(native_coin_name()),
+                    .unwrap_or(native_coin.name.to_string()),
                 logo_uri: self.token.as_ref().map(|it| it.logo_uri.to_string()),
             },
             balance: self.balance.to_owned(),

--- a/src/models/converters/tests/balances.rs
+++ b/src/models/converters/tests/balances.rs
@@ -1,5 +1,6 @@
 use crate::json::{BALANCE_COMPOUND_ETHER, BALANCE_ETHER};
 use crate::models::backend::balances::Balance as BalanceDto;
+use crate::models::chains::NativeCurrency;
 use crate::models::service::balances::Balance;
 use crate::providers::info::{TokenInfo, TokenType};
 
@@ -22,7 +23,12 @@ fn ether_balance() {
     };
 
     let usd_to_fiat = 1.0;
-    let actual = balance_dto.to_balance(usd_to_fiat);
+    let native_currency = NativeCurrency {
+        name: "Ether".to_string(),
+        symbol: "ETH".to_string(),
+        decimals: 18,
+    };
+    let actual = balance_dto.to_balance(usd_to_fiat, &native_currency);
 
     assert_eq!(actual, expected);
 }
@@ -46,7 +52,12 @@ fn erc20_token_balance_usd_balance() {
     };
 
     let usd_to_fiat = 1.0;
-    let actual = balance_dto.to_balance(usd_to_fiat);
+    let native_currency = NativeCurrency {
+        name: "Compound Ether 📈".to_string(),
+        symbol: "cETH".to_string(),
+        decimals: 8,
+    };
+    let actual = balance_dto.to_balance(usd_to_fiat, &native_currency);
 
     assert_eq!(actual, expected);
 }
@@ -70,7 +81,12 @@ fn erc20_token_balance_fiat_is_twice_usd() {
     };
 
     let usd_to_fiat = 2.0;
-    let actual = balance_dto.to_balance(usd_to_fiat);
+    let native_currency = NativeCurrency {
+        name: "Compound Ether 📈".to_string(),
+        symbol: "cETH".to_string(),
+        decimals: 8,
+    };
+    let actual = balance_dto.to_balance(usd_to_fiat, &native_currency);
 
     assert_eq!(actual, expected);
 }

--- a/src/services/balances.rs
+++ b/src/services/balances.rs
@@ -38,12 +38,14 @@ pub async fn balances(
         .await
         .unwrap_or(0.0);
 
+    let native_currency = info_provider.chain_info().await?.native_currency;
+
     let mut total_fiat = 0.0;
 
     let mut service_balances: Vec<Balance> = backend_balances
         .into_iter()
         .map(|it| {
-            let balance = it.to_balance(usd_to_fiat);
+            let balance = it.to_balance(usd_to_fiat, &native_currency);
             total_fiat += balance.fiat_balance.parse::<f64>().unwrap_or(0.0);
             balance
         })

--- a/src/services/balances.rs
+++ b/src/services/balances.rs
@@ -1,11 +1,12 @@
 use crate::cache::cache_operations::RequestCached;
 use crate::config::{balances_cache_duration, balances_request_timeout};
 use crate::models::backend::balances::Balance as BalanceDto;
+use crate::models::chains::{ChainInfo, NativeCurrency};
 use crate::models::service::balances::{Balance, Balances};
 use crate::providers::fiat::FiatInfoProvider;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::utils::context::Context;
-use crate::utils::errors::ApiResult;
+use crate::utils::errors::{ApiError, ApiResult};
 use std::cmp::Ordering;
 
 pub async fn balances(
@@ -38,7 +39,14 @@ pub async fn balances(
         .await
         .unwrap_or(0.0);
 
-    let native_currency = info_provider.chain_info().await?.native_currency;
+    let native_currency: NativeCurrency = match info_provider.chain_info().await {
+        Ok(chainInfo) => chainInfo.native_currency,
+        Err(_) => NativeCurrency {
+            name: "Ether".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+        },
+    };
 
     let mut total_fiat = 0.0;
 


### PR DESCRIPTION
Closes #436 

- Remove `native_coin_decimals`, `native_coin_symbol` and `native_coin_name`
- These functions were reading from the environment variables which no longer apply to the interstellar release