### PR TITLE
Register and Unregister push notification endpoints

### DIFF
--- a/src/models/backend/mod.rs
+++ b/src/models/backend/mod.rs
@@ -1,5 +1,6 @@
 pub mod about;
 pub mod balances;
+pub mod notifications;
 pub mod transactions;
 pub mod transfers;
 pub mod webhooks;

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -1,14 +1,5 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct NotificationRegistrationResult {
-    #[serde(flatten)]
-    pub notification_device_data: DeviceData,
-    pub safes: Vec<String>,
-    pub signatures: Option<Vec<String>>,
-    pub owners_registered: Option<Vec<String>>,
-    pub owners_not_registered: Option<Vec<String>>,
-}
+use crate::models::service::notifications::DeviceData;
+use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -17,24 +8,4 @@ pub struct NotificationRegistrationRequest {
     pub notification_device_data: DeviceData,
     pub safes: Vec<String>,
     pub signatures: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct DeviceData {
-    pub uuid: Option<String>,
-    pub cloud_messaging_token: String,
-    pub build_number: String,
-    pub bundle: String,
-    pub device_type: DeviceType,
-    pub version: String,
-    pub timestamp: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum DeviceType {
-    Android,
-    Ios,
-    Web,
 }

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -2,6 +2,16 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct NotificationRegistrationResult {
+    #[serde(flatten)]
+    pub notification_device_data: NotificationDeviceData,
+    pub signatures: Option<Vec<String>>,
+    pub owners_registered: Option<Vec<String>>,
+    pub owners_not_registered: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceData {
     pub uuid: Option<String>,
     pub cloud_messaging_token: String,
     pub build_number: String,
@@ -9,9 +19,6 @@ pub struct NotificationRegistrationResult {
     pub device_type: DeviceType,
     pub version: String,
     pub timestamp: Option<String>,
-    pub signatures: Option<Vec<String>>,
-    pub owners_registered: Option<Vec<String>>,
-    pub owners_not_registered: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -25,13 +32,8 @@ pub enum DeviceType {
 #[derive(Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationRegistrationRequest {
-    pub uuid: Option<String>,
+    #[serde(flatten)]
+    pub notification_device_data: DeviceData,
     pub safes: Vec<String>,
-    pub cloud_messaging_token: String,
-    pub build_number: String,
-    pub bundle: String,
-    pub device_type: DeviceType,
-    pub version: String,
-    pub timestamp: Option<String>,
     pub signatures: Vec<String>,
 }

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -9,6 +9,15 @@ pub struct NotificationRegistrationResult {
     pub owners_not_registered: Option<Vec<String>>,
 }
 
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationRegistrationRequest {
+    #[serde(flatten)]
+    pub notification_device_data: DeviceData,
+    pub safes: Vec<String>,
+    pub signatures: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceData {
@@ -27,13 +36,4 @@ pub enum DeviceType {
     Android,
     Ios,
     Web,
-}
-
-#[derive(Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct NotificationRegistrationRequest {
-    #[serde(flatten)]
-    pub notification_device_data: DeviceData,
-    pub safes: Vec<String>,
-    pub signatures: Vec<String>,
 }

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -9,7 +9,7 @@ pub struct NotificationRegistrationResult {
     pub owners_not_registered: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationRegistrationRequest {
     #[serde(flatten)]
@@ -18,7 +18,7 @@ pub struct NotificationRegistrationRequest {
     pub signatures: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceData {
     pub uuid: Option<String>,
@@ -30,7 +30,7 @@ pub struct DeviceData {
     pub timestamp: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum DeviceType {
     Android,

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct NotificationRegistrationResult {
     #[serde(flatten)]
     pub notification_device_data: DeviceData,
+    pub safes: Vec<String>,
     pub signatures: Option<Vec<String>>,
     pub owners_registered: Option<Vec<String>>,
     pub owners_not_registered: Option<Vec<String>>,

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct NotificationRegistrationResult {
     #[serde(flatten)]
-    pub notification_device_data: NotificationDeviceData,
+    pub notification_device_data: DeviceData,
     pub signatures: Option<Vec<String>>,
     pub owners_registered: Option<Vec<String>>,
     pub owners_not_registered: Option<Vec<String>>,

--- a/src/models/backend/notifications.rs
+++ b/src/models/backend/notifications.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct NotificationRegistrationResult {
+    pub uuid: Option<String>,
+    pub cloud_messaging_token: String,
+    pub build_number: String,
+    pub bundle: String,
+    pub device_type: DeviceType,
+    pub version: String,
+    pub timestamp: Option<String>,
+    pub signatures: Option<Vec<String>>,
+    pub owners_registered: Option<Vec<String>>,
+    pub owners_not_registered: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum DeviceType {
+    Android,
+    Ios,
+    Web,
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationRegistrationRequest {
+    pub uuid: Option<String>,
+    pub safes: Vec<String>,
+    pub cloud_messaging_token: String,
+    pub build_number: String,
+    pub bundle: String,
+    pub device_type: DeviceType,
+    pub version: String,
+    pub timestamp: Option<String>,
+    pub signatures: Vec<String>,
+}

--- a/src/models/service/mod.rs
+++ b/src/models/service/mod.rs
@@ -1,5 +1,6 @@
 pub mod about;
 pub mod balances;
+pub mod notifications;
 pub mod safes;
 pub mod transactions;
 pub mod utils;

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -1,0 +1,58 @@
+use crate::models::backend::notifications::DeviceType;
+use serde::{Deserialize, Serialize};
+
+/// NotificationRegistrationRequest
+///
+/// <details>
+/// <summary>Example body of NotificationRegistrationRequest registering a device for push notifications</summary>
+///
+/// ```json
+///
+/// {
+///  "uuid": "c50750df-700c-4b17-98ca-b95a5c27ca18",
+///  "cloudMessagingToken": "eWv4Ya6OSaiuDI91S0_C6D:APA91bGpprbGOCa1Qev0h3vlMu2nXa9nWpaL7N9fEcX2G4byZ3TSKXircrMtuWg1H4nSG9Ugu7a7rgY1eDKAR9UaxgaP1egTRj3taqAfAQblApuiWFfRRkyxdD3N23t7wYi9ZBIXZ88Z",
+///  "bundle": "io.gnosis.safe.debug",
+///  "version": "2.13.0",
+///  "deviceType": "ANDROID",
+///  "buildNumber": "703",
+///  "timestamp": "1618906387",
+///  "safeRegistrations": [
+///      {
+///        "chainId": "1",
+///        "safes": [
+///          "0x00E17aA063fbDB3BFdEfc2c3b2c13173d2711a35"
+///        ],
+///        "signatures": "0x4b574e7c729db54b427dd17a6b2ae3481221642a9d61c52a53f77500d98ddc1d739c39dfb117619fb09a20e3f5070d018e62c37f89fb622ae10b56a6be9af5c11b"
+///      },
+///      {
+///        "chainId": "4",
+///        "safes": [
+///          "0x00E17aA063fbDB3BFdEfc2c3b2c13173d2711a35",
+///          "0x00e17Aa063FbDB3bFdEfC2c3b2C13173D2711A36"
+///        ],
+///        "signatures": "0x4b574e7c729db54b427dd17a6b2ae3481221642a9d61c52a53f77500d98ddc1d739c39dfb117619fb09a20e3f5070d018e62c37f89fb622ae10b56a6be9af5c11b"
+///      }
+///    ]
+///  }
+/// ```
+/// </details>
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationRegistrationRequest {
+    pub uuid: Option<String>,
+    pub cloud_messaging_token: String,
+    pub build_number: String,
+    pub bundle: String,
+    pub device_type: DeviceType,
+    pub version: String,
+    pub timestamp: Option<String>,
+    pub safe_registrations: Vec<SafeRegistration>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SafeRegistration {
+    pub chain_id: String,
+    pub safes: Vec<String>,
+    pub signatures: String,
+}

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -49,5 +49,5 @@ pub struct NotificationRegistrationRequest {
 pub struct SafeRegistration {
     pub chain_id: String,
     pub safes: Vec<String>,
-    pub signatures: String,
+    pub signatures: Vec<String>,
 }

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct NotificationRegistrationRequest {
     #[serde(flatten)]
-    pub notification_device_data: DeviceData,
+    pub device_data: DeviceData,
     pub safe_registrations: Vec<SafeRegistration>,
 }
 

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -1,4 +1,4 @@
-use crate::models::backend::notifications::{DeviceData, DeviceType};
+use crate::models::backend::notifications::DeviceData;
 use serde::{Deserialize, Serialize};
 
 /// NotificationRegistrationRequest

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -30,8 +30,10 @@ use serde::{Deserialize, Serialize};
 ///          "0x00E17aA063fbDB3BFdEfc2c3b2c13173d2711a35",
 ///          "0x00e17Aa063FbDB3bFdEfC2c3b2C13173D2711A36"
 ///        ],
-///        "signatures": "0x4b574e7c729db54b427dd17a6b2ae3481221642a9d61c52a53f77500d98ddc1d739c39dfb117619fb09a20e3f5070d018e62c37f89fb622ae10b56a6be9af5c11b"
-///      }
+///        "signatures": [
+///          "0x4b574e7c729db54b427dd17a6b2ae3481221642a9d61c52a53f77500d98ddc1d739c39dfb117619fb09a20e3f5070d018e62c37f89fb622ae10b56a6be9af5c11b"
+///        ]
+///       }
 ///    ]
 ///  }
 /// ```

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -1,4 +1,4 @@
-use crate::models::backend::notifications::DeviceType;
+use crate::models::backend::notifications::{DeviceData, DeviceType};
 use serde::{Deserialize, Serialize};
 
 /// NotificationRegistrationRequest
@@ -39,13 +39,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationRegistrationRequest {
-    pub uuid: Option<String>,
-    pub cloud_messaging_token: String,
-    pub build_number: String,
-    pub bundle: String,
-    pub device_type: DeviceType,
-    pub version: String,
-    pub timestamp: Option<String>,
+    #[serde(flatten)]
+    pub notification_device_data: DeviceData,
     pub safe_registrations: Vec<SafeRegistration>,
 }
 

--- a/src/models/service/notifications.rs
+++ b/src/models/service/notifications.rs
@@ -1,4 +1,3 @@
-use crate::models::backend::notifications::DeviceData;
 use serde::{Deserialize, Serialize};
 
 /// NotificationRegistrationRequest
@@ -44,6 +43,26 @@ pub struct NotificationRegistrationRequest {
     #[serde(flatten)]
     pub device_data: DeviceData,
     pub safe_registrations: Vec<SafeRegistration>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceData {
+    pub uuid: Option<String>,
+    pub cloud_messaging_token: String,
+    pub build_number: String,
+    pub bundle: String,
+    pub device_type: DeviceType,
+    pub version: String,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum DeviceType {
+    Android,
+    Ios,
+    Web,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -44,6 +44,7 @@ pub fn active_routes() -> Vec<Route> {
         chains::get_chains,
         collectibles::get_collectibles,
         notifications::post_notification_registration,
+        notifications::delete_notification_registration,
         safes::get_safe_info,
         transactions::get_transactions,
         transactions::get_transactions_history,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -17,6 +17,8 @@ pub mod collectibles;
 pub mod health;
 #[doc(hidden)]
 pub mod hooks;
+/// # Notification endpoints
+pub mod notifications;
 /// # Safe endpoints
 pub mod safes;
 /// # Transactions endpoints

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -43,6 +43,7 @@ pub fn active_routes() -> Vec<Route> {
         chains::get_chain,
         chains::get_chains,
         collectibles::get_collectibles,
+        notifications::post_notification_registration,
         safes::get_safe_info,
         transactions::get_transactions,
         transactions::get_transactions_history,

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,7 +1,7 @@
 use crate::utils::context::Context;
 
 use crate::models::service::notifications::NotificationRegistrationRequest;
-use crate::services::notifications::post_registration;
+use crate::services::notifications::{delete_registration, post_registration};
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 use rocket::serde::json::Error;
@@ -37,4 +37,14 @@ pub async fn post_notification_registration<'e>(
     registration_request: Result<Json<NotificationRegistrationRequest>, Error<'e>>,
 ) -> ApiResult<content::Json<String>> {
     post_registration(context, registration_request?.0).await
+}
+
+#[delete("/v1/chains/<chain_id>/notificaitons/devices/<uuid>/safes/<safe_address>")]
+pub async fn delete_notification_registration(
+    context: Context<'_>,
+    chain_id: String,
+    uuid: String,
+    safe_address: String,
+) -> ApiResult<()> {
+    delete_registration(context, chain_id, uuid, safe_address).await
 }

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -8,20 +8,18 @@ use rocket::serde::json::Error;
 use rocket::serde::json::Json;
 
 /**
- * `/v1/chains/<chain_id>/transactions/<safe_tx_hash>/confirmations` <br />
- * Returns [TransactionDetails](crate::models::service::transactions::details::TransactionDetails)
+ * `/v1/register/notifications` <br />
+ * Returns `()`
  *
- * # Transaction Confirmation
+ * # Register notifications
  *
- * This endpoint provides a way for submitting confirmations for clients making use of the `safe_tx_hash` as part of the path, and the very same `safe_tx_hash` signed by an owner corresponding to the safe from which the transaction is being sent.
+ * This endpoint provides a way for registering devices for push notifications.
  *
- * If the confirmation is submitted successfully to the core services, then the local cache for that specific transaction is invalidated and the updated transaction details with the confirmation are returned in the request.
+ * One can subscribe to as many safes in different chains as [SafeRegistration](crate::models::service::notifications::SafeRegistration) provided in the payload
  *
  * ## Path
  *
- * `POST /v1/chains/<chain_id>/transactions/<safe_tx_hash>/confirmations`
- *
- * The expected [crate::models::service::transactions::requests::ConfirmationRequest] body for this request, as well as the returned [crate::models::service::transactions::details::TransactionDetails]
+ * `POST /v1/register/notifications`
  *
  * ## Query parameters
  *
@@ -39,6 +37,24 @@ pub async fn post_notification_registration<'e>(
     post_registration(context, registration_request?.0).await
 }
 
+/**
+ * `/v1/chains/<chain_id>/notifications/devices/<uuid>/safes/<safe_address>` <br />
+ * Returns `()`
+ *
+ * # Register notifications
+ *
+ * This endpoint provides a way to unsubscribe from push notifications for a given `uuid`.
+ *
+ * Clients are expected to manage the `uuid` provided originally to the backend.
+ *
+ * ## Path
+ *
+ * `DELETE /v1/chains/<chain_id>/notifications/devices/<uuid>/safes/<safe_address>`
+ *
+ * ## Query parameters
+ *
+ * No query parameters available for this endpoint.
+ */
 #[delete("/v1/chains/<chain_id>/notifications/devices/<uuid>/safes/<safe_address>")]
 pub async fn delete_notification_registration(
     context: Context<'_>,

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -35,11 +35,11 @@ use rocket::serde::json::Json;
 pub async fn post_notification_registration<'e>(
     context: Context<'_>,
     registration_request: Result<Json<NotificationRegistrationRequest>, Error<'e>>,
-) -> ApiResult<content::Json<String>> {
+) -> ApiResult<()> {
     post_registration(context, registration_request?.0).await
 }
 
-#[delete("/v1/chains/<chain_id>/notificaitons/devices/<uuid>/safes/<safe_address>")]
+#[delete("/v1/chains/<chain_id>/notifications/devices/<uuid>/safes/<safe_address>")]
 pub async fn delete_notification_registration(
     context: Context<'_>,
     chain_id: String,

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,6 +1,7 @@
 use crate::utils::context::Context;
 
 use crate::models::service::notifications::NotificationRegistrationRequest;
+use crate::services::notifications::post_registration;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 use rocket::serde::json::Error;
@@ -35,4 +36,5 @@ pub async fn post_notification_registration<'e>(
     context: Context<'_>,
     registration_request: Result<Json<NotificationRegistrationRequest>, Error<'e>>,
 ) -> ApiResult<content::Json<String>> {
+    post_registration(context, registration_request?.0).await
 }

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -3,7 +3,6 @@ use crate::utils::context::Context;
 use crate::models::service::notifications::NotificationRegistrationRequest;
 use crate::services::notifications::{delete_registration, post_registration};
 use crate::utils::errors::ApiResult;
-use rocket::response::content;
 use rocket::serde::json::Error;
 use rocket::serde::json::Json;
 

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -40,7 +40,7 @@ pub async fn post_notification_registration<'e>(
  * `/v1/chains/<chain_id>/notifications/devices/<uuid>/safes/<safe_address>` <br />
  * Returns `()`
  *
- * # Register notifications
+ * # Unregister notifications
  *
  * This endpoint provides a way to unsubscribe from push notifications for a given `uuid`.
  *

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,5 +1,6 @@
 use crate::utils::context::Context;
 
+use crate::models::service::notifications::NotificationRegistrationRequest;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 use rocket::serde::json::Error;
@@ -26,14 +27,12 @@ use rocket::serde::json::Json;
  * No query parameters available for this endpoint.
  */
 #[post(
-    "/v1/transactions/<safe_tx_hash>/confirmations",
+    "/v1/register/notifications",
     format = "application/json",
     data = "<registration_request>"
 )]
 pub async fn post_notification_registration<'e>(
     context: Context<'_>,
-    chain_id: String,
-    safe_tx_hash: String,
     registration_request: Result<Json<NotificationRegistrationRequest>, Error<'e>>,
 ) -> ApiResult<content::Json<String>> {
 }

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,0 +1,39 @@
+use crate::utils::context::Context;
+
+use crate::utils::errors::ApiResult;
+use rocket::response::content;
+use rocket::serde::json::Error;
+use rocket::serde::json::Json;
+
+/**
+ * `/v1/chains/<chain_id>/transactions/<safe_tx_hash>/confirmations` <br />
+ * Returns [TransactionDetails](crate::models::service::transactions::details::TransactionDetails)
+ *
+ * # Transaction Confirmation
+ *
+ * This endpoint provides a way for submitting confirmations for clients making use of the `safe_tx_hash` as part of the path, and the very same `safe_tx_hash` signed by an owner corresponding to the safe from which the transaction is being sent.
+ *
+ * If the confirmation is submitted successfully to the core services, then the local cache for that specific transaction is invalidated and the updated transaction details with the confirmation are returned in the request.
+ *
+ * ## Path
+ *
+ * `POST /v1/chains/<chain_id>/transactions/<safe_tx_hash>/confirmations`
+ *
+ * The expected [crate::models::service::transactions::requests::ConfirmationRequest] body for this request, as well as the returned [crate::models::service::transactions::details::TransactionDetails]
+ *
+ * ## Query parameters
+ *
+ * No query parameters available for this endpoint.
+ */
+#[post(
+    "/v1/transactions/<safe_tx_hash>/confirmations",
+    format = "application/json",
+    data = "<registration_request>"
+)]
+pub async fn post_notification_registration<'e>(
+    context: Context<'_>,
+    chain_id: String,
+    safe_tx_hash: String,
+    registration_request: Result<Json<NotificationRegistrationRequest>, Error<'e>>,
+) -> ApiResult<content::Json<String>> {
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod balances;
 pub mod chains;
 pub mod collectibles;
 pub mod hooks;
+pub mod notifications;
 pub mod safes;
 pub mod transactions_details;
 pub mod transactions_history;

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -19,7 +19,7 @@ pub async fn delete_registration(
     let info_provider = DefaultInfoProvider::new(&chain_id, &context);
     let url = core_uri!(
         info_provider,
-        "/notifications/devices/{}/safes/{}/",
+        "/v1/notifications/devices/{}/safes/{}/",
         uuid,
         safe_address
     )?;
@@ -32,25 +32,22 @@ pub async fn delete_registration(
 pub async fn post_registration(
     context: Context<'_>,
     registration_request: NotificationRegistrationRequest,
-) -> ApiResult<content::Json<String>> {
+) -> ApiResult<()> {
     let client = context.client();
-    let mut results: Vec<NotificationRegistrationResult> = vec![];
 
     for safe_registration in registration_request.safe_registrations.iter() {
         let info_provider = DefaultInfoProvider::new(&safe_registration.chain_id, &context);
-        let url = core_uri!(info_provider, "/notification/devices")?;
+        let url = core_uri!(info_provider, "/v1/notifications/devices/")?;
         let backend_request =
             build_backend_request(&registration_request.device_data, safe_registration);
-        let response = client
+        client
             .post(url.to_string())
             .json(&backend_request)
             .send()
             .await?;
-
-        results.push(serde_json::from_str(&response.text().await?)?);
     }
 
-    Ok(content::Json(serde_json::to_string(&results)?))
+    Ok(())
 }
 
 fn build_backend_request(

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -60,6 +60,6 @@ fn build_backend_request(
     BackendRegistrationRequest {
         notification_device_data: device_data.clone(),
         safes: safe_registration.safes.to_owned(),
-        signatures: vec![safe_registration.signatures.clone()],
+        signatures: safe_registration.signatures.to_owned(),
     }
 }

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -1,0 +1,11 @@
+use crate::models::service::notifications::NotificationRegistrationRequest;
+use crate::utils::context::Context;
+use crate::utils::errors::ApiResult;
+use rocket::response::content;
+
+pub async fn post_registration(
+    context: Context<'_>,
+    registration_request: NotificationRegistrationRequest,
+) -> ApiResult<content::Json<String>> {
+    Ok(content::Json(String::new()))
+}

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -7,6 +7,7 @@ use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
+
 pub async fn post_registration(
     context: Context<'_>,
     registration_request: NotificationRegistrationRequest,

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -8,6 +8,27 @@ use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
 
+pub async fn delete_registration(
+    context: Context<'_>,
+    chain_id: String,
+    uuid: String,
+    safe_address: String,
+) -> ApiResult<()> {
+    let client = context.client();
+
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let url = core_uri!(
+        info_provider,
+        "/notifications/devices/{}/safes/{}/",
+        uuid,
+        safe_address
+    )?;
+
+    client.delete(url).send().await?;
+
+    Ok(())
+}
+
 pub async fn post_registration(
     context: Context<'_>,
     registration_request: NotificationRegistrationRequest,

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -1,12 +1,10 @@
-use crate::models::backend::notifications::{
-    DeviceData, NotificationRegistrationRequest as BackendRegistrationRequest,
-    NotificationRegistrationResult,
+use crate::models::backend::notifications::NotificationRegistrationRequest as BackendRegistrationRequest;
+use crate::models::service::notifications::{
+    DeviceData, NotificationRegistrationRequest, SafeRegistration,
 };
-use crate::models::service::notifications::{NotificationRegistrationRequest, SafeRegistration};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
-use rocket::response::content;
 
 pub async fn delete_registration(
     context: Context<'_>,

--- a/src/services/notifications.rs
+++ b/src/services/notifications.rs
@@ -1,11 +1,38 @@
-use crate::models::service::notifications::NotificationRegistrationRequest;
+use crate::models::backend::notifications::{
+    DeviceData, NotificationRegistrationRequest as BackendRegistrationRequest,
+};
+use crate::models::service::notifications::{NotificationRegistrationRequest, SafeRegistration};
+use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use rocket::response::content;
-
 pub async fn post_registration(
     context: Context<'_>,
     registration_request: NotificationRegistrationRequest,
 ) -> ApiResult<content::Json<String>> {
+    let client = context.client();
+
+    for safe_registration in registration_request.safe_registrations.iter() {
+        let info_provider = DefaultInfoProvider::new(&safe_registration.chain_id, &context);
+        let url = core_uri!(info_provider, "/notification/devices")?;
+        let backend_request =
+            build_backend_request(&registration_request.device_data, safe_registration);
+        // client.post(url.to_string())?.await;
+
+        log::error!("URL: {:#? }", url);
+        log::error!("backend request: {:#? }", backend_request);
+    }
+
     Ok(content::Json(String::new()))
+}
+
+fn build_backend_request(
+    device_data: &DeviceData,
+    safe_registration: &SafeRegistration,
+) -> BackendRegistrationRequest {
+    BackendRegistrationRequest {
+        notification_device_data: device_data.clone(),
+        safes: safe_registration.safes.to_owned(),
+        signatures: vec![safe_registration.signatures.clone()],
+    }
 }


### PR DESCRIPTION
Closes #454 
Closes #455 

Changes:
- Added endpoints for registering and unregistering push notification 
- Introduced `structs` for backend request
- Introduced `struct` for gw request

