### PR TITLE
Add ENS registry address to ChainInfo

### DIFF
--- a/src/models/chains.rs
+++ b/src/models/chains.rs
@@ -10,6 +10,7 @@ pub struct ChainInfo {
     pub block_explorer_url: String,
     pub native_currency: NativeCurrency,
     pub theme: Theme,
+    pub ens_registry_address: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/src/models/tests/chains.rs
+++ b/src/models/tests/chains.rs
@@ -18,7 +18,8 @@ fn chain_info_json() {
           "theme": {
             "textColor": "#fff",
             "backgroundColor": "#000"
-      },
+          },
+          "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"
     });
 
     let expected = ChainInfo {
@@ -37,6 +38,7 @@ fn chain_info_json() {
             text_color: "#fff".to_string(),
             background_color: "#000".to_string(),
         },
+        ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
     };
 
     let actual = serde_json::from_str::<ChainInfo>(&chain_info_json.to_string());

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -23,6 +23,7 @@ async fn core_uri_success_with_params() {
             text_color: "#fff".to_string(),
             background_color: "#000".to_string(),
         },
+        ens_registry_address: None,
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -58,6 +59,7 @@ async fn core_uri_success_without_params() {
             text_color: "#fff".to_string(),
             background_color: "#000".to_string(),
         },
+        ens_registry_address: None,
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider


### PR DESCRIPTION
Closes #463

- Adds ENS registry address `ChainInfo` (optional field)