### PR TITLE
Expose limit query parameter for /chains

### DIFF
--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -44,10 +44,13 @@ pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<cont
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains")]
-pub async fn get_chains(context: Context<'_>) -> ApiResult<content::Json<String>> {
+#[get("/v1/chains?<limit>")]
+pub async fn get_chains(
+    context: Context<'_>,
+    limit: Option<String>,
+) -> ApiResult<content::Json<String>> {
     CacheResponse::new(context.uri())
-        .resp_generator(|| get_chains_paginated(&context))
+        .resp_generator(|| get_chains_paginated(&context, &limit))
         .execute(context.cache())
         .await
 }

--- a/src/services/chains.rs
+++ b/src/services/chains.rs
@@ -7,10 +7,18 @@ use crate::models::commons::Page;
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
 use reqwest::Url;
+use std::collections::HashMap;
 
-pub async fn get_chains_paginated(context: &Context<'_>) -> ApiResult<Page<ChainInfo>> {
-    let mut url =
-        Url::parse(base_config_service_url().as_str()).expect("Bad base config service url");
+pub async fn get_chains_paginated(
+    context: &Context<'_>,
+    limit: &Option<String>,
+) -> ApiResult<Page<ChainInfo>> {
+    let mut queries: HashMap<&str, String> = HashMap::new();
+    if let Some(limit) = limit {
+        queries.insert("limit", limit.to_string());
+    }
+    let mut url = Url::parse_with_params(base_config_service_url().as_str(), queries)
+        .expect("Bad base config service url");
     url.path_segments_mut()
         .expect("Cannot add chain_id to path")
         .extend(["v1", "chains"]);


### PR DESCRIPTION
Closes #473

- The `limit` query parameter is now exposed to the clients so the default number of returned chains on a given page can be adjusted