### PR TITLE
Renamed anything `Ether` to `NativeCoin`

### DIFF
--- a/src/models/converters/balances.rs
+++ b/src/models/converters/balances.rs
@@ -12,6 +12,12 @@ impl BalanceDto {
             .as_ref()
             .map(|_| TokenType::Erc20)
             .unwrap_or(TokenType::NativeToken);
+
+        let logo_uri = if token_type == TokenType::NativeToken {
+            Some(native_coin.logo_url.to_string())
+        } else {
+            self.token.as_ref().map(|it| it.logo_uri.to_string())
+        };
         Balance {
             token_info: TokenInfo {
                 token_type,
@@ -34,7 +40,7 @@ impl BalanceDto {
                     .as_ref()
                     .map(|it| it.name.to_string())
                     .unwrap_or(native_coin.name.to_string()),
-                logo_uri: self.token.as_ref().map(|it| it.logo_uri.to_string()),
+                logo_uri,
             },
             balance: self.balance.to_owned(),
             fiat_balance: fiat_balance.to_string(),

--- a/src/models/converters/balances.rs
+++ b/src/models/converters/balances.rs
@@ -11,7 +11,7 @@ impl BalanceDto {
             .token_address
             .as_ref()
             .map(|_| TokenType::Erc20)
-            .unwrap_or(TokenType::Ether);
+            .unwrap_or(TokenType::NativeToken);
         Balance {
             token_info: TokenInfo {
                 token_type,

--- a/src/models/converters/tests/balances.rs
+++ b/src/models/converters/tests/balances.rs
@@ -15,7 +15,7 @@ fn native_token_balance() {
             decimals: 18,
             symbol: "ETH".to_string(),
             name: "Ether".to_string(),
-            logo_uri: None,
+            logo_uri: Some("https://test.token.image.url".to_string()),
         },
         balance: "7457594371050000001".to_string(),
         fiat_balance: "2523.7991".to_string(),

--- a/src/models/converters/tests/balances.rs
+++ b/src/models/converters/tests/balances.rs
@@ -5,12 +5,12 @@ use crate::models::service::balances::Balance;
 use crate::providers::info::{TokenInfo, TokenType};
 
 #[test]
-fn ether_balance() {
+fn native_token_balance() {
     let balance_dto = serde_json::from_str::<BalanceDto>(BALANCE_ETHER).unwrap();
 
     let expected = Balance {
         token_info: TokenInfo {
-            token_type: TokenType::Ether,
+            token_type: TokenType::NativeToken,
             address: "0x0000000000000000000000000000000000000000".to_string(),
             decimals: 18,
             symbol: "ETH".to_string(),

--- a/src/models/converters/tests/transfer_ether.rs
+++ b/src/models/converters/tests/transfer_ether.rs
@@ -2,7 +2,7 @@ use crate::models::backend::transfers::{
     EtherTransfer as EtherTransferDto, Transfer as TransferDto,
 };
 use crate::models::service::transactions::{
-    EtherTransfer, Transfer, TransferDirection, TransferInfo,
+    NativeCoinTransfer, Transfer, TransferDirection, TransferInfo,
 };
 use crate::providers::address_info::AddressInfo;
 use crate::providers::info::*;
@@ -24,7 +24,7 @@ async fn ether_transfer_dto_ether_incoming_transfer_transaction() {
         recipient: "0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string(),
         recipient_info: None,
         direction: TransferDirection::Incoming,
-        transfer_info: (TransferInfo::Ether(EtherTransfer {
+        transfer_info: (TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "1000000000000000".to_string(),
         })),
     };
@@ -64,7 +64,7 @@ async fn ether_transfer_dto_ether_incoming_transfer_transaction_with_address_inf
         recipient: "0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string(),
         recipient_info: None,
         direction: TransferDirection::Incoming,
-        transfer_info: (TransferInfo::Ether(EtherTransfer {
+        transfer_info: (TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "1000000000000000".to_string(),
         })),
     };
@@ -104,7 +104,7 @@ async fn ether_transfer_dto_ether_outgoing_transfer_transaction_with_address_inf
             logo_uri: None,
         }),
         direction: TransferDirection::Outgoing,
-        transfer_info: (TransferInfo::Ether(EtherTransfer {
+        transfer_info: (TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "1000000000000000".to_string(),
         })),
     };
@@ -123,7 +123,7 @@ async fn ether_transfer_dto_ether_outgoing_transfer_transaction_with_address_inf
 fn ether_transfer_dto_to_transfer_info() {
     let ether_transfer_dto =
         serde_json::from_str::<EtherTransferDto>(crate::json::ETHER_TRANSFER_INCOMING).unwrap();
-    let expected = TransferInfo::Ether(EtherTransfer {
+    let expected = TransferInfo::NativeCoin(NativeCoinTransfer {
         value: "1000000000000000".to_string(),
     });
 

--- a/src/models/converters/tests/transfers.rs
+++ b/src/models/converters/tests/transfers.rs
@@ -4,8 +4,8 @@ use crate::models::backend::transfers::{
 };
 use crate::models::service::transactions::details::TransactionDetails;
 use crate::models::service::transactions::{
-    Erc20Transfer, Erc721Transfer, EtherTransfer, TransactionInfo, TransactionStatus, Transfer,
-    TransferDirection, TransferInfo,
+    Erc20Transfer, Erc721Transfer, NativeCoinTransfer, TransactionInfo, TransactionStatus,
+    Transfer, TransferDirection, TransferInfo,
 };
 use crate::providers::info::*;
 
@@ -115,7 +115,7 @@ async fn ether_transfer_dto_to_transaction_info() {
         recipient: "0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string(),
         recipient_info: None,
         direction: TransferDirection::Incoming,
-        transfer_info: (TransferInfo::Ether(EtherTransfer {
+        transfer_info: (TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "1000000000000000".to_string(),
         })),
     });
@@ -186,7 +186,7 @@ async fn transfer_dto_to_transaction_details() {
             recipient: "0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string(),
             recipient_info: None,
             direction: TransferDirection::Incoming,
-            transfer_info: (TransferInfo::Ether(EtherTransfer {
+            transfer_info: (TransferInfo::NativeCoin(NativeCoinTransfer {
                 value: "1000000000000000".to_string(),
             })),
         }),

--- a/src/models/converters/transactions/mod.rs
+++ b/src/models/converters/transactions/mod.rs
@@ -14,7 +14,7 @@ use crate::models::backend::transactions::{
 use crate::models::commons::{DataDecoded, Operation};
 use crate::models::converters::get_address_info;
 use crate::models::service::transactions::{
-    Custom, Erc20Transfer, Erc721Transfer, EtherTransfer, SettingsChange, TransactionInfo,
+    Custom, Erc20Transfer, Erc721Transfer, NativeCoinTransfer, SettingsChange, TransactionInfo,
     TransactionStatus, Transfer, TransferDirection, TransferInfo,
 };
 use crate::providers::info::{InfoProvider, SafeInfo, TokenInfo, TokenType};
@@ -153,7 +153,7 @@ impl SafeTransaction {
             recipient_info: info_provider.full_address_info_search(&self.to).await.ok(),
             recipient: self.to.to_owned(),
             direction: TransferDirection::Outgoing,
-            transfer_info: TransferInfo::Ether(EtherTransfer {
+            transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
                 value: self.value.as_ref().unwrap().to_string(),
             }),
         }

--- a/src/models/converters/transactions/tests/summary.rs
+++ b/src/models/converters/transactions/tests/summary.rs
@@ -10,8 +10,8 @@ use crate::models::commons::{DataDecoded, Operation, Parameter};
 use crate::models::converters::transactions::data_size;
 use crate::models::service::transactions::summary::{ExecutionInfo, TransactionSummary};
 use crate::models::service::transactions::{
-    Creation, Custom, Erc20Transfer, Erc721Transfer, EtherTransfer, SettingsChange, SettingsInfo,
-    TransactionInfo, TransactionStatus, Transfer, TransferDirection, TransferInfo,
+    Creation, Custom, Erc20Transfer, Erc721Transfer, NativeCoinTransfer, SettingsChange,
+    SettingsInfo, TransactionInfo, TransactionStatus, Transfer, TransferDirection, TransferInfo,
     ID_PREFIX_CREATION_TX, ID_PREFIX_ETHEREUM_TX, ID_PREFIX_MODULE_TX, ID_PREFIX_MULTISIG_TX,
 };
 use crate::providers::address_info::AddressInfo;
@@ -237,7 +237,7 @@ async fn ethereum_tx_to_summary_transaction_with_transfers() {
                 recipient: "".to_string(),
                 recipient_info: None,
                 direction: TransferDirection::Unknown,
-                transfer_info: TransferInfo::Ether(EtherTransfer {
+                transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
                     value: "1".to_string(),
                 }),
             }),
@@ -259,7 +259,7 @@ async fn ethereum_tx_to_summary_transaction_with_transfers() {
                 recipient: "".to_string(),
                 recipient_info: None,
                 direction: TransferDirection::Unknown,
-                transfer_info: TransferInfo::Ether(EtherTransfer {
+                transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
                     value: "1".to_string(),
                 }),
             }),
@@ -522,7 +522,7 @@ async fn multisig_transaction_to_ether_transfer_summary() {
             recipient: "0x938bae50a210b80EA233112800Cd5Bc2e7644300".to_string(),
             recipient_info: None,
             direction: TransferDirection::Outgoing,
-            transfer_info: TransferInfo::Ether(EtherTransfer {
+            transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
                 value: "100000000000000000".to_string(),
             }),
         }),
@@ -689,7 +689,7 @@ async fn multisig_transaction_with_missing_signers() {
             recipient: "0x938bae50a210b80EA233112800Cd5Bc2e7644300".to_string(),
             recipient_info: None,
             direction: TransferDirection::Outgoing,
-            transfer_info: TransferInfo::Ether(EtherTransfer {
+            transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
                 value: "100000000000000000".to_string(),
             }),
         }),

--- a/src/models/converters/transactions/tests/transaction_types.rs
+++ b/src/models/converters/transactions/tests/transaction_types.rs
@@ -2,7 +2,7 @@ use crate::models::backend::transactions::{ModuleTransaction, MultisigTransactio
 use crate::models::commons::ParamValue::SingleValue;
 use crate::models::commons::{DataDecoded, Parameter};
 use crate::models::service::transactions::{
-    Custom, Erc20Transfer, Erc721Transfer, EtherTransfer, SettingsChange, SettingsInfo,
+    Custom, Erc20Transfer, Erc721Transfer, NativeCoinTransfer, SettingsChange, SettingsInfo,
     TransactionInfo, Transfer, TransferDirection, TransferInfo,
 };
 use crate::providers::address_info::AddressInfo;
@@ -121,7 +121,7 @@ async fn transaction_data_size_0_value_greater_than_0() {
         recipient: "0x938bae50a210b80EA233112800Cd5Bc2e7644300".to_string(),
         recipient_info: None,
         direction: TransferDirection::Outgoing,
-        transfer_info: TransferInfo::Ether(EtherTransfer {
+        transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "100000000000000000".to_string(),
         }),
     });
@@ -149,7 +149,7 @@ async fn module_transaction_data_size_0_value_greater_than_0() {
         recipient: "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02".to_string(),
         recipient_info: None,
         direction: TransferDirection::Outgoing,
-        transfer_info: TransferInfo::Ether(EtherTransfer {
+        transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "100000000000000000".to_string(),
         }),
     });

--- a/src/models/converters/transactions/tests/transfer_type_checks.rs
+++ b/src/models/converters/transactions/tests/transfer_type_checks.rs
@@ -2,8 +2,8 @@ use crate::models::backend::transactions::{Confirmation, MultisigTransaction, Sa
 use crate::models::commons::Operation;
 use crate::models::commons::{DataDecoded, Parameter};
 use crate::models::service::transactions::{
-    Erc20Transfer, Erc721Transfer, EtherTransfer, TransactionInfo, Transfer, TransferDirection,
-    TransferInfo,
+    Erc20Transfer, Erc721Transfer, NativeCoinTransfer, TransactionInfo, Transfer,
+    TransferDirection, TransferInfo,
 };
 use crate::providers::info::*;
 use chrono::Utc;
@@ -286,7 +286,7 @@ async fn multisig_tx_check_ether_transfer() {
         recipient: "0x65F8236309e5A99Ff0d129d04E486EBCE20DC7B0".to_string(),
         recipient_info: None,
         direction: TransferDirection::Outgoing,
-        transfer_info: TransferInfo::Ether(EtherTransfer {
+        transfer_info: TransferInfo::NativeCoin(NativeCoinTransfer {
             value: "50000000000000".to_string(),
         }),
     });

--- a/src/models/converters/transfers.rs
+++ b/src/models/converters/transfers.rs
@@ -7,7 +7,8 @@ use crate::models::converters::get_address_info;
 use crate::models::service::transactions::details::TransactionDetails;
 use crate::models::service::transactions::Transfer as ServiceTransfer;
 use crate::models::service::transactions::{
-    Erc20Transfer, Erc721Transfer, EtherTransfer, TransactionInfo, TransactionStatus, TransferInfo,
+    Erc20Transfer, Erc721Transfer, NativeCoinTransfer, TransactionInfo, TransactionStatus,
+    TransferInfo,
 };
 use crate::providers::info::{InfoProvider, TokenInfo, TokenType};
 use crate::utils::errors::ApiResult;
@@ -142,7 +143,7 @@ impl EtherTransferDto {
     }
 
     pub(super) fn to_transfer_info(&self) -> TransferInfo {
-        TransferInfo::Ether(EtherTransfer {
+        TransferInfo::NativeCoin(NativeCoinTransfer {
             value: self.value.clone(),
         })
     }

--- a/src/models/service/transactions/mod.rs
+++ b/src/models/service/transactions/mod.rs
@@ -78,7 +78,7 @@ pub enum TransferDirection {
 pub enum TransferInfo {
     Erc20(Erc20Transfer),
     Erc721(Erc721Transfer),
-    Ether(EtherTransfer),
+    NativeCoin(NativeCoinTransfer),
 }
 
 #[derive(Serialize, Debug, PartialEq)]
@@ -104,7 +104,7 @@ pub struct Erc721Transfer {
 
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct EtherTransfer {
+pub struct NativeCoinTransfer {
     pub value: String,
 }
 

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -36,7 +36,7 @@ lazy_static! {
 pub enum TokenType {
     Erc721,
     Erc20,
-    Ether,
+    NativeToken,
     #[serde(other)]
     Unknown,
 }


### PR DESCRIPTION
Closes #470 

Changes:
 - renamed `TransferInfo::Ether`-> `TransferInfo::NativeCoin`
 - renamed `EtherTransfer` -> `NativeCoinTransfer`
 - renamed `TokenType::Ether` -> `TokenType::NativeCoin` 
 - Fixed issue with `logo_uri` for native coins