### PR TITLE
Adjusting logs for multiple chains

### DIFF
--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -1,1 +1,4 @@
 pub mod performance;
+
+#[cfg(test)]
+mod tests;

--- a/src/monitoring/performance.rs
+++ b/src/monitoring/performance.rs
@@ -1,6 +1,11 @@
 use chrono::Utc;
+use lazy_static::lazy_static;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::{Data, Request, Response};
+
+lazy_static! {
+    static ref CHAIN_ID_PATH_PATTERN: Regex = Regex::new(r"/v1/chains/d{+}/+").unwrap();
+}
 
 pub struct PerformanceMonitor();
 
@@ -18,6 +23,19 @@ impl Fairing for PerformanceMonitor {
     }
 
     async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
+        let raw_path_string = request.uri().path().to_string();
+        let raw_path = request.uri().path();
+
+        log::error!(
+            "raw path: {:#?}",
+            &raw_path.segments().find(|segment| segment == &"chains")
+        );
+        let chain_id = if raw_path_string.contains("/v1/chains/*/*") {
+            raw_path_string.find("/v1/chains//")
+        } else {
+            None
+        };
+
         let path_data = request
             .route()
             .map(|route| route.uri.to_string())
@@ -28,6 +46,18 @@ impl Fairing for PerformanceMonitor {
         let method = request.method().as_str();
         let status_code = response.status().code;
         let delta = Utc::now().timestamp_millis() - cached;
-        log::info!("MT::{}::{}::{}::{}", method, path_data, delta, status_code)
+        if chain_id.is_some() {
+            log::info!(
+                "MT::{}::{}::{}::{}::{}::{}",
+                method,
+                raw_path_string,
+                delta,
+                status_code,
+                path_data,
+                chain_id.unwrap()
+            )
+        } else {
+            log::info!("MT::{}::{}::{}::{}", method, path_data, delta, status_code)
+        }
     }
 }

--- a/src/monitoring/performance.rs
+++ b/src/monitoring/performance.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use lazy_static::lazy_static;
+use regex::Regex;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::{Data, Request, Response};
 

--- a/src/monitoring/performance.rs
+++ b/src/monitoring/performance.rs
@@ -20,6 +20,7 @@ impl Fairing for PerformanceMonitor {
 
     async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         let request_path = request.uri().path();
+
         let chain_id = extract_chain_id(&request_path);
 
         let route = request
@@ -38,7 +39,7 @@ impl Fairing for PerformanceMonitor {
             route,
             delta,
             status_code,
-            request_path.to_string(),
+            request.uri().to_string(), // full path with query params
             chain_id
         );
     }

--- a/src/monitoring/performance.rs
+++ b/src/monitoring/performance.rs
@@ -47,7 +47,8 @@ impl Fairing for PerformanceMonitor {
 
 pub(super) fn extract_chain_id(path: &Path) -> String {
     let chain_id = path.segments().get(2);
-    if path.to_string().starts_with("/v1/chains/") && chain_id.is_some() {
+    let contains_chains = path.segments().get(1).map_or(false, |it| it == "chains");
+    if contains_chains && chain_id.is_some() {
         chain_id.unwrap().to_string()
     } else {
         String::from("-1")

--- a/src/monitoring/tests/mod.rs
+++ b/src/monitoring/tests/mod.rs
@@ -1,0 +1,1 @@
+mod path_patterns;

--- a/src/monitoring/tests/path_patterns.rs
+++ b/src/monitoring/tests/path_patterns.rs
@@ -1,0 +1,11 @@
+#[test]
+fn chain_dependent_endpoint() {}
+
+#[test]
+fn chain_info_endpoint_single() {}
+
+#[test]
+fn chain_info_all() {}
+
+#[test]
+fn chain_independent_endpoint() {}

--- a/src/monitoring/tests/path_patterns.rs
+++ b/src/monitoring/tests/path_patterns.rs
@@ -23,3 +23,11 @@ fn chain_info_all() {
     let actual = extract_chain_id(&uri.path());
     assert_eq!("-1", actual);
 }
+
+#[test]
+fn chain_independent_endpoint() {
+    let uri = uri!("/about/redis/");
+
+    let actual = extract_chain_id(&uri.path());
+    assert_eq!("-1", actual);
+}

--- a/src/monitoring/tests/path_patterns.rs
+++ b/src/monitoring/tests/path_patterns.rs
@@ -1,11 +1,25 @@
-#[test]
-fn chain_dependent_endpoint() {}
+use crate::monitoring::performance::extract_chain_id;
 
 #[test]
-fn chain_info_endpoint_single() {}
+fn chain_dependent_endpoint() {
+    let uri = uri!("/v1/chains/1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b");
+    let actual = extract_chain_id(&uri.path());
+
+    assert_eq!("1", actual);
+}
 
 #[test]
-fn chain_info_all() {}
+fn chain_info_endpoint_single() {
+    let uri = uri!("/v1/chains/1337");
+    let actual = extract_chain_id(&uri.path());
+
+    assert_eq!("1337", actual);
+}
 
 #[test]
-fn chain_independent_endpoint() {}
+fn chain_info_all() {
+    let uri = uri!("/v1/chains");
+
+    let actual = extract_chain_id(&uri.path());
+    assert_eq!("-1", actual);
+}


### PR DESCRIPTION
Closes #450 

Note: 

I can also include the query parameters for `request_path` if you like

We'd need to just add:

```rust
let request_params = request.uri().query();
log::error!("query params: {:#?}", request_params.as_ref().map(|it| it.to_string()));
```