### PR TITLE
Fix config_uri macro uri formatting

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -93,28 +93,3 @@ macro_rules! config_uri {
         config_uri!(full_path)
     }};
 }
-
-#[cfg(test)]
-mod tests {
-    use std::env;
-
-    #[test]
-    fn config_uri_formats_correctly() {
-        env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
-        let expected = "https://config-url-example.com/api/example";
-
-        let actual = config_uri!("/example");
-
-        assert_eq!(expected, actual)
-    }
-
-    #[test]
-    fn config_uri_formats_correctly_with_substitution() {
-        env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
-        let expected = "https://config-url-example.com/api/example/safe";
-
-        let actual = config_uri!("/example/{}", "safe");
-
-        assert_eq!(expected, actual)
-    }
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,3 @@
-use std::env;
 macro_rules! concat_parts {
     ($parts_head:expr) => {
         // `stringify!` will convert the expression *as it is* into a string.
@@ -95,22 +94,27 @@ macro_rules! config_uri {
     }};
 }
 
-#[test]
-fn config_uri_formats_correctly() {
-    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
-    let expected = "https://config-url-example.com/api/example";
+#[cfg(test)]
+mod tests {
+    use std::env;
 
-    let actual = config_uri!("/example");
+    #[test]
+    fn config_uri_formats_correctly() {
+        env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+        let expected = "https://config-url-example.com/api/example";
 
-    assert_eq!(expected, actual)
-}
+        let actual = config_uri!("/example");
 
-#[test]
-fn config_uri_formats_correctly_with_substitution() {
-    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
-    let expected = "https://config-url-example.com/api/example/safe";
+        assert_eq!(expected, actual)
+    }
 
-    let actual = config_uri!("/example/{}", "safe");
+    #[test]
+    fn config_uri_formats_correctly_with_substitution() {
+        env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+        let expected = "https://config-url-example.com/api/example/safe";
 
-    assert_eq!(expected, actual)
+        let actual = config_uri!("/example/{}", "safe");
+
+        assert_eq!(expected, actual)
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+use std::env;
 macro_rules! concat_parts {
     ($parts_head:expr) => {
         // `stringify!` will convert the expression *as it is* into a string.
@@ -86,10 +87,30 @@ macro_rules! core_uri {
 #[macro_export]
 macro_rules! config_uri {
     ($path:expr) => {{
-        format!("{}/{}", $crate::config::base_config_service_url(), $path)
+        format!("{}{}", $crate::config::base_config_service_url(), $path)
     }};
     ($path:literal, $($arg:tt)*) => {{
         let full_path: String = format!($path, $($arg)*);
         config_uri!(full_path)
     }};
+}
+
+#[test]
+fn config_uri_formats_correctly() {
+    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+    let expected = "https://config-url-example.com/api/example";
+
+    let actual = config_uri!("/example");
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn config_uri_formats_correctly_with_substitution() {
+    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+    let expected = "https://config-url-example.com/api/example/safe";
+
+    let actual = config_uri!("/example/{}", "safe");
+
+    assert_eq!(expected, actual)
 }

--- a/src/utils/tests/macros.rs
+++ b/src/utils/tests/macros.rs
@@ -1,0 +1,21 @@
+use std::env;
+
+#[test]
+fn config_uri_formats_correctly() {
+    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+    let expected = "https://config-url-example.com/api/example";
+
+    let actual = config_uri!("/example");
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn config_uri_formats_correctly_with_substitution() {
+    env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
+    let expected = "https://config-url-example.com/api/example/safe";
+
+    let actual = config_uri!("/example/{}", "safe");
+
+    assert_eq!(expected, actual)
+}

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,6 +1,7 @@
 mod data_decoded_utils;
 mod errors;
 mod json;
+mod macros;
 mod method_names;
 mod transactions;
 mod urls;


### PR DESCRIPTION
Closes #489 

- Remove the extra `/` in the `config_uri` macro – the paths already include the initial slash.