### PR TITLE
Adjusted `InvalidationPattern::Chains` to use config service base URL

### DIFF
--- a/src/cache/cache_operations.rs
+++ b/src/cache/cache_operations.rs
@@ -1,7 +1,8 @@
 use crate::cache::cache_op_executors::{cache_response, invalidate, request_cached};
 use crate::cache::{Cache, CACHE_REQS_PREFIX, CACHE_REQS_RESP_PREFIX, CACHE_RESP_PREFIX};
 use crate::config::{
-    default_request_timeout, request_cache_duration, request_error_cache_duration,
+    base_config_service_url, default_request_timeout, request_cache_duration,
+    request_error_cache_duration,
 };
 use crate::providers::info::TOKENS_KEY;
 use crate::utils::errors::ApiResult;
@@ -75,7 +76,7 @@ impl InvalidationPattern {
             InvalidationPattern::Contracts => String::from("*contract*"),
             InvalidationPattern::Tokens => String::from(TOKENS_KEY),
             InvalidationPattern::Chains => {
-                format!("*chain*")
+                format!("*{}*", base_config_service_url())
             }
         }
     }

--- a/src/cache/tests/cache_operations.rs
+++ b/src/cache/tests/cache_operations.rs
@@ -1,5 +1,6 @@
 use crate::cache::cache_operations::{InvalidationPattern, InvalidationScope};
 use crate::cache::{CACHE_REQS_PREFIX, CACHE_REQS_RESP_PREFIX, CACHE_RESP_PREFIX};
+use crate::config::base_config_service_url;
 use crate::providers::info::TOKENS_KEY;
 
 #[test]
@@ -79,8 +80,9 @@ fn invalidation_pattern_collectibles_string() {
 
 #[test]
 fn invalidation_pattern_chains_string() {
+    std::env::set_var("CONFIG_SERVICE_URL", "https://config-url-example.com");
     let invalidation_pattern = InvalidationPattern::Chains;
-    let expected = "*chain*";
+    let expected = format!("*{}*", base_config_service_url());
 
     let actual = invalidation_pattern.to_pattern_string();
 


### PR DESCRIPTION
Closes #504 

Needs manual testing locally, only unit testing passing currently