### PR TITLE
Naive rate-limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +328,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -900,6 +916,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c5d2f987ee8f6dff3fa1a352058dc59b990e447e4c7846aa7d804971314f7b"
+dependencies = [
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand 0.8.3",
+ "smallvec",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +949,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash",
+ "autocfg",
 ]
 
 [[package]]
@@ -1075,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -1412,6 +1455,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "hashbrown 0.8.2",
+]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1788,16 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98dc777a7a39b76b1a26ae9d3f691f4c1bc0455090aa0b64dfa8cb7fc34c135"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2120,10 +2188,12 @@ dependencies = [
  "ethabi 12.0.0",
  "ethcontract-common",
  "ethereum-types 0.10.0",
+ "governor",
  "itertools",
  "lazy_static 1.4.0",
  "log",
  "mockall",
+ "nonzero_ext",
  "proc-macro2",
  "r2d2",
  "redis",
@@ -2340,9 +2410,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ lazy_static = "1.4.0"
 rocket = { git = "https://github.com/SergioBenitez/Rocket", rev = "dd9629697a3cbe45f50645579f41f1a957a92968", features = ["tls", "json"] }
 rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", rev = "dd9629697a3cbe45f50645579f41f1a957a92968" }
 
+governor = "0.3.2"
+nonzero_ext = "0.2.0"
+
 # Force rocket peer-dependencies versions
 proc-macro2 = "1.0.28"
 tokio = "1.6.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod utils;
 #[cfg(test)]
 mod json;
 
+use crate::monitoring::rate_limiter::RateLimiterConfig;
 use crate::routes::error_catchers;
 use cache::redis::create_pool;
 use dotenv::dotenv;
@@ -66,6 +67,7 @@ fn rocket() -> _ {
         .register("/", error_catchers())
         .manage(create_pool())
         .manage(client)
+        .manage(RateLimiterConfig::new())
         .attach(monitoring::performance::PerformanceMonitor())
         .attach(CORS())
 }

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -1,4 +1,5 @@
 pub mod performance;
+pub mod rate_limiter;
 
 #[cfg(test)]
 mod tests;

--- a/src/monitoring/rate_limiter.rs
+++ b/src/monitoring/rate_limiter.rs
@@ -8,7 +8,7 @@ use rocket::{request, Request};
 pub struct RateLimiterConfig {
     pub rate_limiter: RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>,
 }
-const QUOTA: u32 = 1;
+const QUOTA: u32 = 1; // second
 
 #[derive(Debug)]
 pub enum RateLimiterGuard {

--- a/src/monitoring/rate_limiter.rs
+++ b/src/monitoring/rate_limiter.rs
@@ -8,11 +8,12 @@ use rocket::{request, Request};
 pub struct RateLimiterConfig {
     pub rate_limiter: RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>,
 }
-const QUOTA: u32 = 20;
+const QUOTA: u32 = 1;
 
 #[derive(Debug)]
-pub enum RateLimitError {
+pub enum RateLimiterGuard {
     LimitReached,
+    MayStillRequest,
 }
 
 impl RateLimiterConfig {
@@ -24,18 +25,18 @@ impl RateLimiterConfig {
 }
 
 #[rocket::async_trait]
-impl<'r> FromRequest<'r> for RateLimiterConfig {
-    type Error = RateLimitError;
+impl<'r> FromRequest<'r> for RateLimiterGuard {
+    type Error = RateLimiterGuard;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         let rate_limiter_config = request.rocket().state::<RateLimiterConfig>().unwrap();
         let rate_limiter = &rate_limiter_config.rate_limiter;
 
         match rate_limiter.check_key(&request.uri().to_string()) {
-            Ok(_) => request::Outcome::Forward(()),
+            Ok(_) => request::Outcome::Success(RateLimiterGuard::MayStillRequest),
             Err(_) => request::Outcome::Failure((
                 Status::from_code(429u16).unwrap(),
-                RateLimitError::LimitReached,
+                RateLimiterGuard::LimitReached,
             )),
         }
     }

--- a/src/monitoring/rate_limiter.rs
+++ b/src/monitoring/rate_limiter.rs
@@ -1,0 +1,42 @@
+use governor::state::keyed::DefaultKeyedStateStore;
+use governor::{clock, Quota, RateLimiter};
+use nonzero_ext::*;
+use rocket::http::Status;
+use rocket::request::FromRequest;
+use rocket::{request, Request};
+
+pub struct RateLimiterConfig {
+    pub rate_limiter: RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>,
+}
+const QUOTA: u32 = 20;
+
+#[derive(Debug)]
+pub enum RateLimitError {
+    LimitReached,
+}
+
+impl RateLimiterConfig {
+    pub fn new() -> Self {
+        RateLimiterConfig {
+            rate_limiter: RateLimiter::keyed(Quota::per_second(nonzero!(QUOTA))),
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for RateLimiterConfig {
+    type Error = RateLimitError;
+
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+        let rate_limiter_config = request.rocket().state::<RateLimiterConfig>().unwrap();
+        let rate_limiter = &rate_limiter_config.rate_limiter;
+
+        match rate_limiter.check_key(&request.uri().to_string()) {
+            Ok(_) => request::Outcome::Forward(()),
+            Err(_) => request::Outcome::Failure((
+                Status::from_code(429u16).unwrap(),
+                RateLimitError::LimitReached,
+            )),
+        }
+    }
+}

--- a/src/monitoring/rate_limiter.rs
+++ b/src/monitoring/rate_limiter.rs
@@ -8,7 +8,7 @@ use rocket::{request, Request};
 pub struct RateLimiterConfig {
     pub rate_limiter: RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>,
 }
-const QUOTA: u32 = 1; // second
+const QUOTA: u32 = 1; // request per url per second
 
 #[derive(Debug)]
 pub enum RateLimiterGuard {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -55,7 +55,8 @@ pub fn active_routes() -> Vec<Route> {
         hooks::flush,
         health::health,
         utils::post_data_decoder,
-        utils::post_safe_gas_estimation
+        utils::post_safe_gas_estimation,
+        utils::get_bomb_me,
     ]
 }
 

--- a/src/routes/utils.rs
+++ b/src/routes/utils.rs
@@ -1,4 +1,5 @@
 use crate::models::service::utils::{DataDecoderRequest, SafeTransactionEstimationRequest};
+use crate::monitoring::rate_limiter::RateLimiterGuard;
 use crate::services::utils;
 use crate::services::utils::request_data_decoded;
 use crate::utils::context::Context;
@@ -120,4 +121,11 @@ pub async fn post_safe_gas_estimation<'e>(
         )
         .await?,
     )?))
+}
+
+#[get("/bomb-me")]
+pub async fn get_bomb_me(_rate_limiter: RateLimiterGuard) -> ApiResult<content::Json<String>> {
+    Ok(content::Json(
+        "{ \"successfully\": \"bombed\" }".to_string(),
+    ))
 }


### PR DESCRIPTION
Ecosystem friday project toy branch

Brief description:
`governor` is a rate limiter that is thread safe. I incorporated it using `rocket` states and created a `request guard` that we can use to mark any endpoints for which we want to return `429`s when abussed. Currently the request `url` is used which could be problematic for a safe monitored from different devices. It would be cool to evaluate a different `key` against which we rate limit. Also, for the sake of testing, the current rate limit is of `1 request per second`. We should define the behaviour better if we decide to keep this.

Current state: `1 request per uri per second`

Next steps:
- Caching 429's long?  
- Can we configure `governor` to rate limit longer? 