### PR TITLE
Fix REDIS_URL param in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     env_file:
       - .env
     environment:
-      - REDIS_URL="redis://redis"
+      - REDIS_URL=redis://redis
     depends_on:
       - redis
     ports:


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [X] You are using the nightly version of rust `rustup default nighly`
- [X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ ] [**Actually not required for this change**] You ran `cargo fmt` on the code base before submitting
