### PR TITLE
Remove blockExplorerUri from ChainInfo payload

### DIFF
--- a/src/json/chains/rinkeby.json
+++ b/src/json/chains/rinkeby.json
@@ -5,7 +5,6 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
-  "blockExplorerUri": "https://blockexplorer.com",
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}"

--- a/src/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/json/chains/rinkeby_fixed_gas_price.json
@@ -5,7 +5,6 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
-  "blockExplorerUri": "https://blockexplorer.com",
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}"

--- a/src/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/json/chains/rinkeby_rpc_auth_unknown.json
@@ -5,7 +5,6 @@
     "authentication": "SOME_RANDOM_AUTH",
     "value": "https://someurl.com/rpc"
   },
-  "blockExplorerUri": "https://blockexplorer.com",
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}"

--- a/src/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/json/chains/rinkeby_rpc_no_auth.json
@@ -5,7 +5,6 @@
     "authentication": "NO_AUTHENTICATION",
     "value": "https://someurl.com/rpc"
   },
-  "blockExplorerUri": "https://blockexplorer.com",
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}"

--- a/src/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/json/chains/rinkeby_unknown_gas_price.json
@@ -5,7 +5,6 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
-  "blockExplorerUri": "https://blockexplorer.com",
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}"

--- a/src/models/backend/chains.rs
+++ b/src/models/backend/chains.rs
@@ -8,7 +8,6 @@ pub struct ChainInfo {
     pub chain_id: String,
     pub chain_name: String,
     pub rpc_uri: RpcUri,
-    pub block_explorer_uri: String,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/models/converters/chains.rs
+++ b/src/models/converters/chains.rs
@@ -21,7 +21,6 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 },
                 value: chain_info.rpc_uri.value,
             },
-            block_explorer_uri: chain_info.block_explorer_uri,
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,

--- a/src/models/service/chains.rs
+++ b/src/models/service/chains.rs
@@ -8,7 +8,6 @@ pub struct ChainInfo {
     pub chain_id: String,
     pub chain_name: String,
     pub rpc_uri: RpcUri,
-    pub block_explorer_uri: String,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/models/tests/chains.rs
+++ b/src/models/tests/chains.rs
@@ -18,7 +18,6 @@ fn chain_info_json() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -58,7 +57,6 @@ fn chain_info_json_with_fixed_gas_price() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -96,7 +94,6 @@ fn chain_info_json_with_unknown_gas_price_type() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -133,7 +130,6 @@ fn chain_info_json_with_no_rpc_authentication() {
             authentication: RpcAuthentication::NoAuthentication,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -174,7 +170,6 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             authentication: RpcAuthentication::Unknown,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -215,7 +210,6 @@ fn chain_info_json_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -254,7 +248,6 @@ fn unknown_gas_price_type_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -291,7 +284,6 @@ fn no_authentication_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::NoAuthentication,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -332,7 +324,6 @@ fn unknown_authentication_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::Unknown,
             value: "https://someurl.com/rpc".to_string(),
         },
-        block_explorer_uri: "https://blockexplorer.com".to_string(),
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -18,7 +18,6 @@ async fn core_uri_success_with_params() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
-        block_explorer_uri: "".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
@@ -65,7 +64,6 @@ async fn core_uri_success_without_params() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
-        block_explorer_uri: "".to_string(),
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),


### PR DESCRIPTION
- Removes `blockExplorerUri` from both the config service and from the payload exposed to the clients since it is no longer required (after the introduction of `blockExplorerUriTemplate`)