### PR TITLE
Added a 3 second timeout to contract info request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,7 +2081,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "cargo-watch",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "2.0.1"
+version = "2.0.3"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
 edition = "2018"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -100,6 +100,10 @@ pub fn safe_app_info_request_timeout() -> u64 {
     u64_with_default("SAFE_APP_INFO_REQUEST_TIMEOUT", 3000)
 }
 
+pub fn contract_info_request_timeout() -> u64 {
+    u64_with_default("CONTRACT_INFO_REQUEST_TIMEOUT", 3000)
+}
+
 pub fn transaction_request_timeout() -> u64 {
     u64_with_default("TRANSACTION_REQUEST_TIMEOUT", 30000)
 }

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -3,9 +3,10 @@ use crate::cache::redis::ServiceCache;
 use crate::cache::Cache;
 use crate::config::{
     address_info_cache_duration, base_exchange_api_url, base_transaction_service_url,
-    exchange_api_cache_duration, long_error_duration, safe_app_info_request_timeout,
-    safe_app_manifest_cache_duration, safe_info_cache_duration, safe_info_request_timeout,
-    short_error_duration, token_info_cache_duration, token_info_request_timeout,
+    contract_info_request_timeout, exchange_api_cache_duration, long_error_duration,
+    safe_app_info_request_timeout, safe_app_manifest_cache_duration, safe_info_cache_duration,
+    safe_info_request_timeout, short_error_duration, token_info_cache_duration,
+    token_info_request_timeout,
 };
 use crate::models::commons::Page;
 use crate::providers::address_info::{AddressInfo, ContractInfo};
@@ -151,6 +152,7 @@ impl<C: Cache> InfoProvider for DefaultInfoProvider<'_, C> {
             address
         );
         let contract_info_json = RequestCached::new(url)
+            .request_timeout(contract_info_request_timeout())
             .cache_duration(address_info_cache_duration())
             .error_cache_duration(long_error_duration())
             .execute(self.client, self.cache)


### PR DESCRIPTION
Addresses part of the issue with #546 

`contract_info` is not fetched with a timeout. Added a 3 second, since this method is repeatedly called in the transaction history list. 