### PR TITLE
Removed response caching for `ChainInfo` endpoints

### DIFF
--- a/src/routes/chains.rs
+++ b/src/routes/chains.rs
@@ -1,5 +1,3 @@
-use crate::cache::cache_operations::CacheResponse;
-use crate::config::chain_info_cache_duration;
 use crate::services::chains::{get_chains_paginated, get_single_chain};
 use crate::utils::context::Context;
 use crate::utils::errors::ApiResult;
@@ -20,11 +18,9 @@ use rocket::response::content;
  */
 #[get("/v1/chains/<chain_id>")]
 pub async fn get_chain(context: Context<'_>, chain_id: String) -> ApiResult<content::Json<String>> {
-    CacheResponse::new(context.uri())
-        .duration(chain_info_cache_duration())
-        .resp_generator(|| get_single_chain(&context, &chain_id))
-        .execute(context.cache())
-        .await
+    Ok(content::Json(serde_json::to_string(
+        &get_single_chain(&context, &chain_id).await?,
+    )?))
 }
 
 /**
@@ -45,8 +41,7 @@ pub async fn get_chains(
     context: Context<'_>,
     limit: Option<String>,
 ) -> ApiResult<content::Json<String>> {
-    CacheResponse::new(context.uri())
-        .resp_generator(|| get_chains_paginated(&context, &limit))
-        .execute(context.cache())
-        .await
+    Ok(content::Json(serde_json::to_string(
+        &get_chains_paginated(&context, &limit).await?,
+    )?))
 }


### PR DESCRIPTION
Closes #565 

We no longer cache the response from the cgw. Given redis available glob-patterns for regex, we can't come with an effective pattern that solely matches `ChainInfo` related keys, without invalidating other keys by accident.