### PR TITLE
Use cargo-llvm-cov for coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,38 +49,22 @@ jobs:
           profile: minimal
           toolchain: ${{ env.TOOLCHAIN }}
           override: true
-          components: rustfmt
+          components: llvm-tools-preview
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Run tests
-        uses: actions-rs/cargo@v1
+      - uses: actions-rs/install@v0.1
         with:
-          command: test
-          args: --verbose --all --locked
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'
+          crate: cargo-llvm-cov
+          version: latest
 
-      - name: Cache grcov
-        id: grcov-cache
-        uses: actions/cache@v2.1.5
+      - uses: actions-rs/cargo@v1
         with:
-          path: /home/runner/.cargo/bin/
-          key: ${{ runner.os }}-grcov-v080
+          command: llvm-cov
+          args: --all-features --workspace --lcov --output-path lcov.info
 
-      - name: Fetch grcov
-        if: steps.grcov-cache.outputs.cache-hit != 'true'
-        run: curl --location https://github.com/mozilla/grcov/releases/download/v0.8.0/grcov-linux-x86_64.tar.bz2 | tar jxf -
-
-      - name: Run grcov
-        id: coverage
-        uses: actions-rs/grcov@v0.1
-        with:
-          config: ./.github/action-rs/grcov.yml
-
-      - name: Coveralls upload
+      - name: Upload coverage
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dump.rdb
 **/venv
 
 *.DS_Store*
+
+lcov.info


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ ] You are using the nightly version of rust `rustup default nighly`
- [ ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ ] You ran `cargo fmt` on the code base before submitting
