### PR TITLE
Add support for multiple oracles per chain

### DIFF
--- a/src/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/json/chains/rinkeby_fixed_gas_price.json
@@ -21,9 +21,11 @@
     "backgroundColor": "#000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": {
-    "type": "fixed",
-    "weiValue": "1000000000"
-  },
+  "gasPrice": [
+    {
+      "type": "fixed",
+      "weiValue": "1000000000"
+    }
+  ],
   "recommendedMasterCopyVersion": "1.1.1"
 }

--- a/src/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/json/chains/rinkeby_multiple_gas_price.json
@@ -17,8 +17,8 @@
     "logoUri": "https://test.token.image.url"
   },
   "theme": {
-    "textColor": "#ffffff",
-    "backgroundColor": "#000000"
+    "textColor": "#fff",
+    "backgroundColor": "#000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
   "gasPrice": [
@@ -27,6 +27,10 @@
       "uri": "https://gaspriceoracle.com/",
       "gasParameter": "average",
       "gweiFactor": "10"
+    },
+    {
+      "type": "fixed",
+      "weiValue": "1000000000"
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1"

--- a/src/json/chains/rinkeby_no_gas_price.json
+++ b/src/json/chains/rinkeby_no_gas_price.json
@@ -17,17 +17,10 @@
     "logoUri": "https://test.token.image.url"
   },
   "theme": {
-    "textColor": "#ffffff",
-    "backgroundColor": "#000000"
+    "textColor": "#fff",
+    "backgroundColor": "#000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": [
-    {
-      "type": "oracle",
-      "uri": "https://gaspriceoracle.com/",
-      "gasParameter": "average",
-      "gweiFactor": "10"
-    }
-  ],
+  "gasPrice": [],
   "recommendedMasterCopyVersion": "1.1.1"
 }

--- a/src/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/json/chains/rinkeby_rpc_auth_unknown.json
@@ -21,11 +21,13 @@
     "backgroundColor": "#000000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": {
-    "type": "oracle",
-    "uri": "https://gaspriceoracle.com/",
-    "gasParameter": "average",
-    "gweiFactor": "10"
-  },
+  "gasPrice": [
+    {
+      "type": "oracle",
+      "uri": "https://gaspriceoracle.com/",
+      "gasParameter": "average",
+      "gweiFactor": "10"
+    }
+  ],
   "recommendedMasterCopyVersion": "1.1.1"
 }

--- a/src/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/json/chains/rinkeby_rpc_no_auth.json
@@ -21,11 +21,13 @@
     "backgroundColor": "#000000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": {
-    "type": "oracle",
-    "uri": "https://gaspriceoracle.com/",
-    "gasParameter": "average",
-    "gweiFactor": "10"
-  },
+  "gasPrice": [
+    {
+      "type": "oracle",
+      "uri": "https://gaspriceoracle.com/",
+      "gasParameter": "average",
+      "gweiFactor": "10"
+    }
+  ],
   "recommendedMasterCopyVersion": "1.1.1"
 }

--- a/src/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/json/chains/rinkeby_unknown_gas_price.json
@@ -21,9 +21,11 @@
     "backgroundColor": "#000000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": {
-    "type": "very fancy oracle",
-    "fancyValue": "fancy"
-  },
+  "gasPrice": [
+    {
+      "type": "very fancy oracle",
+      "fancyValue": "fancy"
+    }
+  ],
   "recommendedMasterCopyVersion": "1.1.1"
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -122,6 +122,8 @@ pub const TX_DETAILS_WITH_ORIGIN: &str = include_str!("results/tx_details_with_o
 
 pub const CHAIN_INFO_RINKEBY: &str = include_str!("chains/rinkeby.json");
 pub const CHAIN_INFO_RINKEBY_FIXED_GAS_PRICE: &str = include_str!("chains/rinkeby_fixed_gas_price.json");
+pub const CHAIN_INFO_RINKEBY_MULTIPLE_GAS_PRICE: &str = include_str!("chains/rinkeby_multiple_gas_price.json");
+pub const CHAIN_INFO_RINKEBY_NO_GAS_PRICE: &str = include_str!("chains/rinkeby_no_gas_price.json");
 pub const CHAIN_INFO_RINKEBY_UNKNOWN_GAS_PRICE: &str = include_str!("chains/rinkeby_unknown_gas_price.json");
 pub const CHAIN_INFO_RINKEBY_RPC_NO_AUTHENTICATION: &str = include_str!("chains/rinkeby_rpc_no_auth.json");
 pub const CHAIN_INFO_RINKEBY_RPC_UNKNOWN_AUTHENTICATION: &str = include_str!("chains/rinkeby_rpc_auth_unknown.json");

--- a/src/models/backend/chains.rs
+++ b/src/models/backend/chains.rs
@@ -12,7 +12,7 @@ pub struct ChainInfo {
     pub native_currency: NativeCurrency,
     pub theme: Theme,
     pub ens_registry_address: Option<String>,
-    pub gas_price: GasPrice,
+    pub gas_price: Vec<GasPrice>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]

--- a/src/models/converters/chains.rs
+++ b/src/models/converters/chains.rs
@@ -36,19 +36,25 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 background_color: chain_info.theme.background_color,
             },
             ens_registry_address: chain_info.ens_registry_address,
-            gas_price: match chain_info.gas_price {
-                GasPrice::Oracle {
-                    uri,
-                    gas_parameter,
-                    gwei_factor,
-                } => ServiceGasPrice::Oracle {
-                    uri,
-                    gas_parameter,
-                    gwei_factor,
-                },
-                GasPrice::Fixed { wei_value } => ServiceGasPrice::Fixed { wei_value },
-                GasPrice::Unknown => ServiceGasPrice::Unknown,
-            },
+            gas_price: chain_info
+                .gas_price
+                .iter()
+                .map(|gas_price| match gas_price {
+                    GasPrice::Oracle {
+                        uri,
+                        gas_parameter,
+                        gwei_factor,
+                    } => ServiceGasPrice::Oracle {
+                        uri: uri.to_string(),
+                        gas_parameter: gas_parameter.to_string(),
+                        gwei_factor: gwei_factor.to_string(),
+                    },
+                    GasPrice::Fixed { wei_value } => ServiceGasPrice::Fixed {
+                        wei_value: wei_value.to_string(),
+                    },
+                    GasPrice::Unknown => ServiceGasPrice::Unknown,
+                })
+                .collect::<Vec<ServiceGasPrice>>(),
         }
     }
 }

--- a/src/models/service/chains.rs
+++ b/src/models/service/chains.rs
@@ -12,7 +12,7 @@ pub struct ChainInfo {
     pub native_currency: NativeCurrency,
     pub theme: Theme,
     pub ens_registry_address: Option<String>,
-    pub gas_price: GasPrice,
+    pub gas_price: Vec<GasPrice>,
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]

--- a/src/models/tests/chains.rs
+++ b/src/models/tests/chains.rs
@@ -33,11 +33,11 @@ fn chain_info_json() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: GasPrice::Oracle {
+        gas_price: vec![GasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(crate::json::CHAIN_INFO_RINKEBY);
@@ -72,12 +72,92 @@ fn chain_info_json_with_fixed_gas_price() {
             background_color: "#000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: GasPrice::Fixed {
+        gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000000".to_string(),
-        },
+        }],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(crate::json::CHAIN_INFO_RINKEBY_FIXED_GAS_PRICE);
+
+    assert!(actual.is_ok());
+    assert_eq!(expected, actual.unwrap());
+}
+
+#[test]
+fn chain_info_json_with_no_gas_price() {
+    let expected = ChainInfo {
+        recommended_master_copy_version: "1.1.1".to_string(),
+        transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        chain_id: "4".to_string(),
+        chain_name: "Rinkeby".to_string(),
+        rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc".to_string(),
+        },
+        block_explorer_uri_template: BlockExplorerUriTemplate {
+            address: "https://blockexplorer.com/{{address}}".to_string(),
+            tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+        },
+        native_currency: NativeCurrency {
+            name: "Ether".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: Theme {
+            text_color: "#fff".to_string(),
+            background_color: "#000".to_string(),
+        },
+        ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
+        gas_price: vec![],
+    };
+
+    let actual = serde_json::from_str::<ChainInfo>(crate::json::CHAIN_INFO_RINKEBY_NO_GAS_PRICE);
+
+    assert!(actual.is_ok());
+    assert_eq!(expected, actual.unwrap());
+}
+
+#[test]
+fn chain_info_json_with_multiple_gas_price() {
+    let expected = ChainInfo {
+        recommended_master_copy_version: "1.1.1".to_string(),
+        transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        chain_id: "4".to_string(),
+        chain_name: "Rinkeby".to_string(),
+        rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc".to_string(),
+        },
+        block_explorer_uri_template: BlockExplorerUriTemplate {
+            address: "https://blockexplorer.com/{{address}}".to_string(),
+            tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+        },
+        native_currency: NativeCurrency {
+            name: "Ether".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: Theme {
+            text_color: "#fff".to_string(),
+            background_color: "#000".to_string(),
+        },
+        ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
+        gas_price: vec![
+            GasPrice::Oracle {
+                uri: "https://gaspriceoracle.com/".to_string(),
+                gas_parameter: "average".to_string(),
+                gwei_factor: "10".to_string(),
+            },
+            GasPrice::Fixed {
+                wei_value: "1000000000".to_string(),
+            },
+        ],
+    };
+
+    let actual =
+        serde_json::from_str::<ChainInfo>(crate::json::CHAIN_INFO_RINKEBY_MULTIPLE_GAS_PRICE);
 
     assert!(actual.is_ok());
     assert_eq!(expected, actual.unwrap());
@@ -109,7 +189,7 @@ fn chain_info_json_with_unknown_gas_price_type() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: GasPrice::Unknown,
+        gas_price: vec![GasPrice::Unknown],
     };
 
     let actual =
@@ -145,11 +225,11 @@ fn chain_info_json_with_no_rpc_authentication() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: GasPrice::Oracle {
+        gas_price: vec![GasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let actual =
@@ -185,11 +265,11 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: GasPrice::Oracle {
+        gas_price: vec![GasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -225,11 +305,11 @@ fn chain_info_json_to_service_chain_info() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: ServiceGasPrice::Oracle {
+        gas_price: vec![ServiceGasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(crate::json::CHAIN_INFO_RINKEBY).unwrap();
@@ -263,7 +343,7 @@ fn unknown_gas_price_type_to_service_chain_info() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: ServiceGasPrice::Unknown,
+        gas_price: vec![ServiceGasPrice::Unknown],
     };
 
     let from_json =
@@ -299,11 +379,11 @@ fn no_authentication_to_service_chain_info() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: ServiceGasPrice::Oracle {
+        gas_price: vec![ServiceGasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let from_json =
@@ -339,11 +419,11 @@ fn unknown_authentication_to_service_chain_info() {
             background_color: "#000000".to_string(),
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
-        gas_price: ServiceGasPrice::Oracle {
+        gas_price: vec![ServiceGasPrice::Oracle {
             uri: "https://gaspriceoracle.com/".to_string(),
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
-        },
+        }],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -33,9 +33,9 @@ async fn core_uri_success_with_params() {
             background_color: "#000".to_string(),
         },
         ens_registry_address: None,
-        gas_price: GasPrice::Fixed {
+        gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
-        },
+        }],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -79,9 +79,9 @@ async fn core_uri_success_without_params() {
             background_color: "#000".to_string(),
         },
         ens_registry_address: None,
-        gas_price: GasPrice::Fixed {
+        gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
-        },
+        }],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider


### PR DESCRIPTION
Related with the following issue: https://github.com/gnosis/safe-config-service/issues/209

- The `config-service` now returns a collection of oracles (instead of a single oracle) so the deserialisation on the CGW side was adjusted. The payload exposed to the clients was also adjusted to reflect this new collection.