### PR TITLE
Included `vpcTransactionService` in the struct `backend::ChainInfo`

### DIFF
--- a/src/json/chains/rinkeby.json
+++ b/src/json/chains/rinkeby.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/json/chains/rinkeby_fixed_gas_price.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/json/chains/rinkeby_multiple_gas_price.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_no_gas_price.json
+++ b/src/json/chains/rinkeby_no_gas_price.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/json/chains/rinkeby_rpc_auth_unknown.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/json/chains/rinkeby_rpc_no_auth.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/json/chains/rinkeby_unknown_gas_price.json
@@ -12,6 +12,7 @@
     "txHash": "https://blockexplorer.com/{{txHash}}"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
+  "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! core_uri {
     ($info_provider:tt, $path:expr) => {{
         let result: ApiResult<String> =
         match $info_provider.chain_info().await {
-            Ok(chain_info) => Ok(format!("{}/api{}",chain_info.transaction_service, $path)),
+            Ok(chain_info) => Ok(format!("{}/api{}",chain_info.vpc_transaction_service, $path)),
             Err(error) => Err(error,)
         };
         result

--- a/src/models/backend/chains.rs
+++ b/src/models/backend/chains.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 pub struct ChainInfo {
     pub recommended_master_copy_version: String,
     pub transaction_service: String,
+    pub vpc_transaction_service: String,
     pub chain_id: String,
     pub chain_name: String,
     pub l2: bool,

--- a/src/models/tests/chains.rs
+++ b/src/models/tests/chains.rs
@@ -12,6 +12,8 @@ fn chain_info_json() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -53,6 +55,8 @@ fn chain_info_json_with_fixed_gas_price() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -92,6 +96,8 @@ fn chain_info_json_with_no_gas_price() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -129,6 +135,8 @@ fn chain_info_json_with_multiple_gas_price() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -176,6 +184,8 @@ fn chain_info_json_with_unknown_gas_price_type() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -214,6 +224,8 @@ fn chain_info_json_with_no_rpc_authentication() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,
@@ -256,6 +268,8 @@ fn chain_info_json_with_unknown_rpc_authentication() {
     let expected = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "4".to_string(),
         chain_name: "Rinkeby".to_string(),
         l2: false,

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -12,7 +12,7 @@ async fn core_uri_success_with_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
-        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+        vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
         chain_name: "".to_string(),
@@ -54,7 +54,7 @@ async fn core_uri_success_with_params() {
         exclude_spam
     );
 
-    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+    assert_eq!(url.unwrap(), "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
 }
 
 #[rocket::async_test]
@@ -62,7 +62,7 @@ async fn core_uri_success_without_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
-        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+        vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
         chain_name: "".to_string(),
@@ -99,7 +99,7 @@ async fn core_uri_success_without_params() {
     let url = core_uri!(mock_info_provider, "/some/path");
 
     assert_eq!(
-        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
+        "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/some/path",
         url.unwrap()
     );
 }

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -12,6 +12,8 @@ async fn core_uri_success_with_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "1".to_string(),
         chain_name: "".to_string(),
         l2: false,
@@ -60,6 +62,8 @@ async fn core_uri_success_without_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        vpc_transaction_service: "http://rinkeby-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
         chain_id: "1".to_string(),
         chain_name: "".to_string(),
         l2: false,


### PR DESCRIPTION
Closes #625 

Uses `vpcTransactionService` field within the `core_uri!` macro, but the field is not exposed to clients.