### PR TITLE
Enable public core services url on debug builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all --locked
+          args: --release --verbose --all --locked
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --verbose --all --locked
+          args: --verbose --all --locked
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+use crate::models::backend::chains::ChainInfo;
+
 macro_rules! concat_parts {
     ($parts_head:expr) => {
         // `stringify!` will convert the expression *as it is* into a string.
@@ -65,13 +67,23 @@ macro_rules! to_hex_string {
     }};
 }
 
+#[cfg(debug_assertions)]
+pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
+    return chain_info.transaction_service;
+}
+
+#[cfg(not(debug_assertions))]
+pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
+    return chain_info.vpc_transaction_service;
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! core_uri {
     ($info_provider:tt, $path:expr) => {{
         let result: ApiResult<String> =
         match $info_provider.chain_info().await {
-            Ok(chain_info) => Ok(format!("{}/api{}",chain_info.vpc_transaction_service, $path)),
+            Ok(chain_info) => Ok(format!("{}/api{}",crate::macros::get_transaction_service_host(chain_info), $path)),
             Err(error) => Err(error,)
         };
         result

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -1,3 +1,4 @@
+#[cfg(not(debug_assertions))]
 use crate::models::backend::chains::{
     BlockExplorerUriTemplate, ChainInfo, GasPrice, NativeCurrency, RpcAuthentication, RpcUri, Theme,
 };
@@ -5,6 +6,7 @@ use crate::providers::info::*;
 use crate::utils::errors::ApiResult;
 
 #[rocket::async_test]
+#[cfg(not(debug_assertions))]
 async fn core_uri_success_with_params() {
     let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
     let trusted = false;
@@ -54,10 +56,11 @@ async fn core_uri_success_with_params() {
         exclude_spam
     );
 
-    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+    assert_eq!(url.unwrap(), "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
 }
 
 #[rocket::async_test]
+#[cfg(not(debug_assertions))]
 async fn core_uri_success_without_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
@@ -99,7 +102,7 @@ async fn core_uri_success_without_params() {
     let url = core_uri!(mock_info_provider, "/some/path");
 
     assert_eq!(
-        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
+        "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/some/path",
         url.unwrap()
     );
 }

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -54,7 +54,7 @@ async fn core_uri_success_with_params() {
         exclude_spam
     );
 
-    assert_eq!(url.unwrap(), "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
 }
 
 #[rocket::async_test]
@@ -99,7 +99,7 @@ async fn core_uri_success_without_params() {
     let url = core_uri!(mock_info_provider, "/some/path");
 
     assert_eq!(
-        "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/some/path",
+        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
         url.unwrap()
     );
 }

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -1,4 +1,3 @@
-#[cfg(not(debug_assertions))]
 use crate::models::backend::chains::{
     BlockExplorerUriTemplate, ChainInfo, GasPrice, NativeCurrency, RpcAuthentication, RpcUri, Theme,
 };
@@ -6,7 +5,6 @@ use crate::providers::info::*;
 use crate::utils::errors::ApiResult;
 
 #[rocket::async_test]
-#[cfg(not(debug_assertions))]
 async fn core_uri_success_with_params() {
     let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
     let trusted = false;
@@ -56,11 +54,10 @@ async fn core_uri_success_with_params() {
         exclude_spam
     );
 
-    assert_eq!(url.unwrap(), "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
 }
 
 #[rocket::async_test]
-#[cfg(not(debug_assertions))]
 async fn core_uri_success_without_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
@@ -102,7 +99,7 @@ async fn core_uri_success_without_params() {
     let url = core_uri!(mock_info_provider, "/some/path");
 
     assert_eq!(
-        "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/some/path",
+        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
         url.unwrap()
     );
 }


### PR DESCRIPTION
Closes #629 

- The `core_uri` macro now uses the public transaction service url if `debug_assertions` is `True` – this means that the public url will be used by non-optimised builds by default
- To test with the internal cluster url the `--release` flag can be used (in order to use the `release` profile which has `debug_assertions` disabled) – `cargo run --release` (see https://doc.rust-lang.org/cargo/reference/profiles.html#release)