### PR TITLE
Config flag to toggle between `vpcTransactionService` and `transactionService`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,7 +20,7 @@ WEBHOOK_TOKEN=some_random_token
 # Set to "debug" when developing
 RUST_LOG=safe_client_gateway=error,safe_client_gateway::monitoring=info
 LOG_ALL_ERROR_RESPONSES=false
-VPC_TRANSACTION_SERVICE_URI=false
+VPC_TRANSACTION_SERVICE_URI=true
 
 # Time outs for caches (all have defaults in the code)
 # The unit of these values is "milliseconds"

--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,7 @@ WEBHOOK_TOKEN=some_random_token
 # Set to "debug" when developing
 RUST_LOG=safe_client_gateway=error,safe_client_gateway::monitoring=info
 LOG_ALL_ERROR_RESPONSES=false
+VPC_TRANSACTION_SERVICE_URI=false
 
 # Time outs for caches (all have defaults in the code)
 # The unit of these values is "milliseconds"

--- a/.github/action-rs/grcov.yml
+++ b/.github/action-rs/grcov.yml
@@ -4,6 +4,7 @@ llvm: true
 filter: covered
 output-type: lcov
 output-path: ./lcov.info
+binary-path: ./target/release
 coveralls-token: ${{ secrets.COVERALLS_TOKEN }}
 prefix-dir: .
 ignore:

--- a/.github/action-rs/grcov.yml
+++ b/.github/action-rs/grcov.yml
@@ -4,7 +4,6 @@ llvm: true
 filter: covered
 output-type: lcov
 output-path: ./lcov.info
-binary-path: ./target/release
 coveralls-token: ${{ secrets.COVERALLS_TOKEN }}
 prefix-dir: .
 ignore:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all --locked
+          args: --verbose --all --locked -- --test-threads 1
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all --locked
+          args: --release --verbose --all --locked
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ github.workspace }}/lcov.info
+          path-to-lcov: ${{ steps.coverage.outputs.report }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --verbose --all --locked
+          args: --verbose --all --locked
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Awarnings'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -165,6 +165,10 @@ pub fn feature_flag_nested_decoding() -> bool {
     bool_with_default("FEATURE_FLAG_NESTED_DECODING", true)
 }
 
+pub fn vpc_transaction_service_uri() -> bool {
+    bool_with_default("VPC_TRANSACTION_SERVICE_URI", false)
+}
+
 pub fn build_number() -> Option<String> {
     option_env!("BUILD_NUMBER").map(|it| it.to_string())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -166,7 +166,7 @@ pub fn feature_flag_nested_decoding() -> bool {
 }
 
 pub fn vpc_transaction_service_uri() -> bool {
-    bool_with_default("VPC_TRANSACTION_SERVICE_URI", false)
+    bool_with_default("VPC_TRANSACTION_SERVICE_URI", true)
 }
 
 pub fn build_number() -> Option<String> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+use crate::models::backend::chains::ChainInfo;
 macro_rules! concat_parts {
     ($parts_head:expr) => {
         // `stringify!` will convert the expression *as it is* into a string.
@@ -65,13 +66,23 @@ macro_rules! to_hex_string {
     }};
 }
 
+#[cfg(debug_assertions)]
+pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
+    return chain_info.transaction_service;
+}
+
+#[cfg(not(debug_assertions))]
+pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
+    return chain_info.vpc_transaction_service;
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! core_uri {
     ($info_provider:tt, $path:expr) => {{
         let result: ApiResult<String> =
         match $info_provider.chain_info().await {
-            Ok(chain_info) => Ok(format!("{}/api{}",chain_info.vpc_transaction_service, $path)),
+            Ok(chain_info) => Ok(format!("{}/api{}", crate::macros::get_transaction_service_host(chain_info), $path)),
             Err(error) => Err(error,)
         };
         result

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+use crate::config::vpc_transaction_service_uri;
 use crate::models::backend::chains::ChainInfo;
 macro_rules! concat_parts {
     ($parts_head:expr) => {
@@ -66,14 +67,12 @@ macro_rules! to_hex_string {
     }};
 }
 
-#[cfg(debug_assertions)]
 pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
-    return chain_info.transaction_service;
-}
-
-#[cfg(not(debug_assertions))]
-pub fn get_transaction_service_host(chain_info: ChainInfo) -> String {
-    return chain_info.vpc_transaction_service;
+    if vpc_transaction_service_uri() {
+        chain_info.vpc_transaction_service
+    } else {
+        chain_info.transaction_service
+    }
 }
 
 #[doc(hidden)]

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -5,6 +5,7 @@ use crate::providers::info::*;
 use crate::utils::errors::ApiResult;
 
 #[rocket::async_test]
+#[cfg(not(debug_assertions))]
 async fn core_uri_success_with_params() {
     let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
     let trusted = false;
@@ -58,6 +59,7 @@ async fn core_uri_success_with_params() {
 }
 
 #[rocket::async_test]
+#[cfg(not(debug_assertions))]
 async fn core_uri_success_without_params() {
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
@@ -100,6 +102,108 @@ async fn core_uri_success_without_params() {
 
     assert_eq!(
         "http://mainnet-safe-transaction-web.safe.svc.cluster.local/api/some/path",
+        url.unwrap()
+    );
+}
+
+#[rocket::async_test]
+#[cfg(debug_assertions)]
+async fn core_uri_success_with_params() {
+    let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
+    let trusted = false;
+    let exclude_spam = true;
+    let chain_info = ChainInfo {
+        recommended_master_copy_version: "1.1.1".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
+        chain_id: "1".to_string(),
+        chain_name: "".to_string(),
+        l2: false,
+        description: "Random description".to_string(),
+        rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        block_explorer_uri_template: BlockExplorerUriTemplate {
+            address: "".to_string(),
+            tx_hash: "".to_string(),
+        },
+        native_currency: NativeCurrency {
+            name: "".to_string(),
+            symbol: "".to_string(),
+            decimals: 0,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: Theme {
+            text_color: "#fff".to_string(),
+            background_color: "#000".to_string(),
+        },
+        ens_registry_address: None,
+        gas_price: vec![GasPrice::Fixed {
+            wei_value: "1000000".to_string(),
+        }],
+    };
+    let mut mock_info_provider = MockInfoProvider::new();
+    mock_info_provider
+        .expect_chain_info()
+        .times(1)
+        .return_once(move || Ok(chain_info));
+    let url = core_uri!(
+        mock_info_provider,
+        "/v1/safes/{}/balances/usd/?trusted={}&exclude_spam={}",
+        safe_address,
+        trusted,
+        exclude_spam
+    );
+
+    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+}
+
+#[rocket::async_test]
+#[cfg(debug_assertions)]
+async fn core_uri_success_without_params() {
+    let chain_info = ChainInfo {
+        recommended_master_copy_version: "1.1.1".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
+            .to_string(),
+        chain_id: "1".to_string(),
+        chain_name: "".to_string(),
+        l2: false,
+        description: "Random description".to_string(),
+        rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        block_explorer_uri_template: BlockExplorerUriTemplate {
+            address: "".to_string(),
+            tx_hash: "".to_string(),
+        },
+        native_currency: NativeCurrency {
+            name: "".to_string(),
+            symbol: "".to_string(),
+            decimals: 0,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: Theme {
+            text_color: "#fff".to_string(),
+            background_color: "#000".to_string(),
+        },
+        ens_registry_address: None,
+        gas_price: vec![GasPrice::Fixed {
+            wei_value: "1000000".to_string(),
+        }],
+    };
+    let mut mock_info_provider = MockInfoProvider::new();
+    mock_info_provider
+        .expect_chain_info()
+        .times(1)
+        .return_once(move || Ok(chain_info));
+    let url = core_uri!(mock_info_provider, "/some/path");
+
+    assert_eq!(
+        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
         url.unwrap()
     );
 }

--- a/src/services/tests/backend_url.rs
+++ b/src/services/tests/backend_url.rs
@@ -5,8 +5,8 @@ use crate::providers::info::*;
 use crate::utils::errors::ApiResult;
 
 #[rocket::async_test]
-#[cfg(not(debug_assertions))]
-async fn core_uri_success_with_params() {
+async fn core_uri_success_with_params_prod() {
+    std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "true");
     let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
     let trusted = false;
     let exclude_spam = true;
@@ -59,8 +59,8 @@ async fn core_uri_success_with_params() {
 }
 
 #[rocket::async_test]
-#[cfg(not(debug_assertions))]
-async fn core_uri_success_without_params() {
+async fn core_uri_success_without_params_prod() {
+    std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "true");
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
@@ -107,8 +107,8 @@ async fn core_uri_success_without_params() {
 }
 
 #[rocket::async_test]
-#[cfg(debug_assertions)]
-async fn core_uri_success_with_params() {
+async fn core_uri_success_with_params_local() {
+    std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "false");
     let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
     let trusted = false;
     let exclude_spam = true;
@@ -161,8 +161,8 @@ async fn core_uri_success_with_params() {
 }
 
 #[rocket::async_test]
-#[cfg(debug_assertions)]
-async fn core_uri_success_without_params() {
+async fn core_uri_success_without_params_local() {
+    std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "false");
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
         transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),


### PR DESCRIPTION
Closes #629 
Closes #631 

In addition to what @fmrsabino suggested, I introduced tests with debug assertion to also validate what is ran in the local setup unoptimized case.

However, after the discussion in the comments we have decided to stick to an implementation based on a environment variable, as this would allow better testability. 

Important note: From this PR onward tests would run in single thread, as changes to env vars behave non-deterministically in an async setup.
