### PR TITLE
Add disabledWallets to ChainInfo

### DIFF
--- a/src/common/models/backend/chains.rs
+++ b/src/common/models/backend/chains.rs
@@ -17,6 +17,7 @@ pub struct ChainInfo {
     pub theme: Theme,
     pub ens_registry_address: Option<String>,
     pub gas_price: Vec<GasPrice>,
+    pub disabled_wallets: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -60,6 +60,7 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                     GasPrice::Unknown => ServiceGasPrice::Unknown,
                 })
                 .collect::<Vec<ServiceGasPrice>>(),
+            disabled_wallets: chain_info.disabled_wallets,
         }
     }
 }

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -17,6 +17,7 @@ pub struct ChainInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ens_registry_address: Option<String>,
     pub gas_price: Vec<GasPrice>,
+    pub disabled_wallets: Vec<String>,
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]

--- a/src/routes/chains/tests/chains.rs
+++ b/src/routes/chains/tests/chains.rs
@@ -43,6 +43,7 @@ fn chain_info_json() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY);
@@ -85,6 +86,7 @@ fn chain_info_json_with_fixed_gas_price() {
         gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000000".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let actual =
@@ -126,6 +128,7 @@ fn chain_info_json_with_no_gas_price() {
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![],
+        disabled_wallets: vec![],
     };
 
     let actual =
@@ -176,6 +179,7 @@ fn chain_info_json_with_multiple_gas_price() {
                 wei_value: "1000000000".to_string(),
             },
         ],
+        disabled_wallets: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -218,6 +222,7 @@ fn chain_info_json_with_unknown_gas_price_type() {
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![GasPrice::Unknown],
+        disabled_wallets: vec![],
     };
 
     let actual =
@@ -263,6 +268,7 @@ fn chain_info_json_with_no_rpc_authentication() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -309,6 +315,7 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -352,6 +359,7 @@ fn chain_info_json_to_service_chain_info() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let from_json =
@@ -390,6 +398,7 @@ fn unknown_gas_price_type_to_service_chain_info() {
         },
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![ServiceGasPrice::Unknown],
+        disabled_wallets: vec![],
     };
 
     let from_json =
@@ -433,6 +442,7 @@ fn no_authentication_to_service_chain_info() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(
@@ -477,12 +487,57 @@ fn unknown_authentication_to_service_chain_info() {
             gas_parameter: "average".to_string(),
             gwei_factor: "10".to_string(),
         }],
+        disabled_wallets: vec![],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(
         crate::tests::json::CHAIN_INFO_RINKEBY_RPC_UNKNOWN_AUTHENTICATION,
     )
     .unwrap();
+    let actual: ServiceChainInfo = from_json.into();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn disabled_wallets_to_service_chain_info() {
+    let expected = ServiceChainInfo {
+        transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        chain_id: "4".to_string(),
+        chain_name: "Rinkeby".to_string(),
+        short_name: "rin".to_string(),
+        l2: false,
+        description: "Random description".to_string(),
+        rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc".to_string(),
+        },
+        block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
+            address: "https://blockexplorer.com/{{address}}".to_string(),
+            tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+        },
+        native_currency: ServiceNativeCurrency {
+            name: "Ether".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: ServiceTheme {
+            text_color: "#ffffff".to_string(),
+            background_color: "#000000".to_string(),
+        },
+        ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
+        gas_price: vec![ServiceGasPrice::Oracle {
+            uri: "https://gaspriceoracle.com/".to_string(),
+            gas_parameter: "average".to_string(),
+            gwei_factor: "10".to_string(),
+        }],
+        disabled_wallets: vec![String::from("metamask"), String::from("trezor")],
+    };
+
+    let from_json =
+        serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY_DISABLED_WALLETS)
+            .unwrap();
     let actual: ServiceChainInfo = from_json.into();
 
     assert_eq!(expected, actual);

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -42,6 +42,7 @@ async fn core_uri_success_with_params_prod() {
         gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
         }],
+        disabled_wallets: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -94,6 +95,7 @@ async fn core_uri_success_without_params_prod() {
         gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
         }],
+        disabled_wallets: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -146,6 +148,7 @@ async fn core_uri_success_with_params_local() {
         gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
         }],
+        disabled_wallets: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -198,6 +201,7 @@ async fn core_uri_success_without_params_local() {
         gas_price: vec![GasPrice::Fixed {
             wei_value: "1000000".to_string(),
         }],
+        disabled_wallets: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider

--- a/src/tests/json/chains/polygon.json
+++ b/src/tests/json/chains/polygon.json
@@ -37,5 +37,6 @@
     }
   ],
   "ensRegistryAddress": null,
-  "recommendedMasterCopyVersion": "1.3.0"
+  "recommendedMasterCopyVersion": "1.3.0",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby.json
+++ b/src/tests/json/chains/rinkeby.json
@@ -33,5 +33,6 @@
       "gweiFactor": "10"
     }
   ],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby_disabled_wallets.json
+++ b/src/tests/json/chains/rinkeby_disabled_wallets.json
@@ -21,8 +21,8 @@
     "logoUri": "https://test.token.image.url"
   },
   "theme": {
-    "textColor": "#fff",
-    "backgroundColor": "#000"
+    "textColor": "#ffffff",
+    "backgroundColor": "#000000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
   "gasPrice": [
@@ -31,12 +31,11 @@
       "uri": "https://gaspriceoracle.com/",
       "gasParameter": "average",
       "gweiFactor": "10"
-    },
-    {
-      "type": "fixed",
-      "weiValue": "1000000000"
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [
+    "metamask",
+    "trezor"
+  ]
 }

--- a/src/tests/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/tests/json/chains/rinkeby_fixed_gas_price.json
@@ -31,5 +31,6 @@
       "weiValue": "1000000000"
     }
   ],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby_no_gas_price.json
+++ b/src/tests/json/chains/rinkeby_no_gas_price.json
@@ -26,5 +26,6 @@
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
   "gasPrice": [],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
@@ -33,5 +33,6 @@
       "gweiFactor": "10"
     }
   ],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/tests/json/chains/rinkeby_rpc_no_auth.json
@@ -33,5 +33,6 @@
       "gweiFactor": "10"
     }
   ],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/tests/json/chains/rinkeby_unknown_gas_price.json
@@ -31,5 +31,6 @@
       "fancyValue": "fancy"
     }
   ],
-  "recommendedMasterCopyVersion": "1.1.1"
+  "recommendedMasterCopyVersion": "1.1.1",
+  "disabledWallets": []
 }

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -133,6 +133,8 @@ pub const CHAIN_INFO_RINKEBY_RPC_NO_AUTHENTICATION: &str =
     include_str!("chains/rinkeby_rpc_no_auth.json");
 pub const CHAIN_INFO_RINKEBY_RPC_UNKNOWN_AUTHENTICATION: &str =
     include_str!("chains/rinkeby_rpc_auth_unknown.json");
+pub const CHAIN_INFO_RINKEBY_DISABLED_WALLETS: &str =
+    include_str!("chains/rinkeby_disabled_wallets.json");
 
 pub const POLYGON_SAFE_APPS: &str = include_str!("safe_apps/polygon_safe_apps.json");
 


### PR DESCRIPTION
Closes #674 

- Adds `disabledWallets` field to `ChainInfo`


```javascript
GET /v1/chains/<chain_id>/

[
  {
    "chainId": <string>,
    "disabledWallets": [<string>] // eg.: [ "metamask", "trust"]
    ...
  }
]
```