### PR TITLE
Add Block Explorer API template to ChainInfo

### DIFF
--- a/src/common/models/backend/chains.rs
+++ b/src/common/models/backend/chains.rs
@@ -73,4 +73,5 @@ pub enum RpcAuthentication {
 pub struct BlockExplorerUriTemplate {
     pub address: String,
     pub tx_hash: String,
+    pub api: String,
 }

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -29,6 +29,7 @@ impl From<BackendChainInfo> for ServiceChainInfo {
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,
+                api: chain_info.block_explorer_uri_template.api,
             },
             native_currency: ServiceNativeCurrency {
                 name: chain_info.native_currency.name,

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -74,4 +74,5 @@ pub enum RpcAuthentication {
 pub struct BlockExplorerUriTemplate {
     pub address: String,
     pub tx_hash: String,
+    pub api: String,
 }

--- a/src/routes/chains/tests/chains.rs
+++ b/src/routes/chains/tests/chains.rs
@@ -26,6 +26,7 @@ fn chain_info_json() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -71,6 +72,7 @@ fn chain_info_json_with_fixed_gas_price() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -115,6 +117,7 @@ fn chain_info_json_with_no_gas_price() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -157,6 +160,7 @@ fn chain_info_json_with_multiple_gas_price() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -209,6 +213,7 @@ fn chain_info_json_with_unknown_gas_price_type() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -251,6 +256,7 @@ fn chain_info_json_with_no_rpc_authentication() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -298,6 +304,7 @@ fn chain_info_json_with_unknown_rpc_authentication() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: NativeCurrency {
             name: "Ether".to_string(),
@@ -342,6 +349,7 @@ fn chain_info_json_to_service_chain_info() {
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: ServiceNativeCurrency {
             name: "Ether".to_string(),
@@ -385,6 +393,7 @@ fn unknown_gas_price_type_to_service_chain_info() {
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: ServiceNativeCurrency {
             name: "Ether".to_string(),
@@ -425,6 +434,7 @@ fn no_authentication_to_service_chain_info() {
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: ServiceNativeCurrency {
             name: "Ether".to_string(),
@@ -470,6 +480,7 @@ fn unknown_authentication_to_service_chain_info() {
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: ServiceNativeCurrency {
             name: "Ether".to_string(),
@@ -515,6 +526,7 @@ fn disabled_wallets_to_service_chain_info() {
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
         },
         native_currency: ServiceNativeCurrency {
             name: "Ether".to_string(),

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -27,6 +27,7 @@ async fn core_uri_success_with_params_prod() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
+            api: "".to_string(),
         },
         native_currency: NativeCurrency {
             name: "".to_string(),
@@ -80,6 +81,7 @@ async fn core_uri_success_without_params_prod() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
+            api: "".to_string(),
         },
         native_currency: NativeCurrency {
             name: "".to_string(),
@@ -133,6 +135,7 @@ async fn core_uri_success_with_params_local() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
+            api: "".to_string(),
         },
         native_currency: NativeCurrency {
             name: "".to_string(),
@@ -186,6 +189,7 @@ async fn core_uri_success_without_params_local() {
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
+            api: "".to_string(),
         },
         native_currency: NativeCurrency {
             name: "".to_string(),

--- a/src/tests/json/chains/polygon.json
+++ b/src/tests/json/chains/polygon.json
@@ -14,7 +14,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://polygonscan.com/address/{{address}}",
-    "txHash": "https://polygonscan.com/tx/{{txHash}}"
+    "txHash": "https://polygonscan.com/tx/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "nativeCurrency": {
     "name": "Matic",

--- a/src/tests/json/chains/rinkeby.json
+++ b/src/tests/json/chains/rinkeby.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_disabled_wallets.json
+++ b/src/tests/json/chains/rinkeby_disabled_wallets.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/tests/json/chains/rinkeby_fixed_gas_price.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/tests/json/chains/rinkeby_multiple_gas_price.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_no_gas_price.json
+++ b/src/tests/json/chains/rinkeby_no_gas_price.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/tests/json/chains/rinkeby_rpc_no_auth.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",

--- a/src/tests/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/tests/json/chains/rinkeby_unknown_gas_price.json
@@ -10,7 +10,8 @@
   },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
-    "txHash": "https://blockexplorer.com/{{txHash}}"
+    "txHash": "https://blockexplorer.com/{{txHash}}",
+    "api": "https://blockexplorer.com/api"
   },
   "transactionService": "https://safe-transaction.rinkeby.staging.gnosisdev.com",
   "vpcTransactionService": "http://rinkeby-safe-transaction-web.safe.svc.cluster.local",


### PR DESCRIPTION
Closes #673 

- Adds `api` to `blockExplorerUriTemplate` in `ChainInfo`

```javascript
GET /v1/chains/<chain_id>/

{
  "chainId": <string>,
  "chainName": <string>,
  "blockExplorerUriTemplate": {
      "address": "https://etherscan.io/address/{{address}}", // example
      "txHash": "https://etherscan.io/tx/{{txHash}}" // example
      "api": "https://api.etherscan.io/api/?module={{module}}&action={{action}}&address={{address}}" // new field example
    },
  ...
}
```