### PR TITLE
Add Features to ChainInfo

### DIFF
--- a/src/common/models/backend/chains.rs
+++ b/src/common/models/backend/chains.rs
@@ -18,6 +18,7 @@ pub struct ChainInfo {
     pub ens_registry_address: Option<String>,
     pub gas_price: Vec<GasPrice>,
     pub disabled_wallets: Vec<String>,
+    pub features: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -62,6 +62,7 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 })
                 .collect::<Vec<ServiceGasPrice>>(),
             disabled_wallets: chain_info.disabled_wallets,
+            features: chain_info.features,
         }
     }
 }

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -18,6 +18,7 @@ pub struct ChainInfo {
     pub ens_registry_address: Option<String>,
     pub gas_price: Vec<GasPrice>,
     pub disabled_wallets: Vec<String>,
+    pub features: Vec<String>,
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]

--- a/src/routes/chains/tests/chains.rs
+++ b/src/routes/chains/tests/chains.rs
@@ -45,6 +45,7 @@ fn chain_info_json() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY);
@@ -89,6 +90,7 @@ fn chain_info_json_with_fixed_gas_price() {
             wei_value: "1000000000".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual =
@@ -132,6 +134,7 @@ fn chain_info_json_with_no_gas_price() {
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual =
@@ -184,6 +187,7 @@ fn chain_info_json_with_multiple_gas_price() {
             },
         ],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -228,6 +232,7 @@ fn chain_info_json_with_unknown_gas_price_type() {
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![GasPrice::Unknown],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual =
@@ -275,6 +280,7 @@ fn chain_info_json_with_no_rpc_authentication() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -323,6 +329,7 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let actual = serde_json::from_str::<ChainInfo>(
@@ -368,6 +375,7 @@ fn chain_info_json_to_service_chain_info() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let from_json =
@@ -408,6 +416,7 @@ fn unknown_gas_price_type_to_service_chain_info() {
         ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
         gas_price: vec![ServiceGasPrice::Unknown],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let from_json =
@@ -453,6 +462,7 @@ fn no_authentication_to_service_chain_info() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(
@@ -499,6 +509,7 @@ fn unknown_authentication_to_service_chain_info() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
 
     let from_json = serde_json::from_str::<ChainInfo>(
@@ -545,10 +556,57 @@ fn disabled_wallets_to_service_chain_info() {
             gwei_factor: "10".to_string(),
         }],
         disabled_wallets: vec![String::from("metamask"), String::from("trezor")],
+        features: vec![],
     };
 
     let from_json =
         serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY_DISABLED_WALLETS)
+            .unwrap();
+    let actual: ServiceChainInfo = from_json.into();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn features_to_service_chain_info() {
+    let expected = ServiceChainInfo {
+        transaction_service: "https://safe-transaction.rinkeby.staging.gnosisdev.com".to_string(),
+        chain_id: "4".to_string(),
+        chain_name: "Rinkeby".to_string(),
+        short_name: "rin".to_string(),
+        l2: false,
+        description: "Random description".to_string(),
+        rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc".to_string(),
+        },
+        block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
+            address: "https://blockexplorer.com/{{address}}".to_string(),
+            tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
+            api: "https://blockexplorer.com/api".to_string(),
+        },
+        native_currency: ServiceNativeCurrency {
+            name: "Ether".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+            logo_uri: "https://test.token.image.url".to_string(),
+        },
+        theme: ServiceTheme {
+            text_color: "#ffffff".to_string(),
+            background_color: "#000000".to_string(),
+        },
+        ens_registry_address: Some("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF".to_string()),
+        gas_price: vec![ServiceGasPrice::Oracle {
+            uri: "https://gaspriceoracle.com/".to_string(),
+            gas_parameter: "average".to_string(),
+            gwei_factor: "10".to_string(),
+        }],
+        disabled_wallets: vec![],
+        features: vec![String::from("Feature 1"), String::from("Feature 2")],
+    };
+
+    let from_json =
+        serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY_ENABLED_FEATURES)
             .unwrap();
     let actual: ServiceChainInfo = from_json.into();
 

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -44,6 +44,7 @@ async fn core_uri_success_with_params_prod() {
             wei_value: "1000000".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -98,6 +99,7 @@ async fn core_uri_success_without_params_prod() {
             wei_value: "1000000".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -152,6 +154,7 @@ async fn core_uri_success_with_params_local() {
             wei_value: "1000000".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider
@@ -206,6 +209,7 @@ async fn core_uri_success_without_params_local() {
             wei_value: "1000000".to_string(),
         }],
         disabled_wallets: vec![],
+        features: vec![],
     };
     let mut mock_info_provider = MockInfoProvider::new();
     mock_info_provider

--- a/src/tests/json/chains/polygon.json
+++ b/src/tests/json/chains/polygon.json
@@ -39,5 +39,6 @@
   ],
   "ensRegistryAddress": null,
   "recommendedMasterCopyVersion": "1.3.0",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby.json
+++ b/src/tests/json/chains/rinkeby.json
@@ -35,5 +35,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_disabled_wallets.json
+++ b/src/tests/json/chains/rinkeby_disabled_wallets.json
@@ -38,5 +38,6 @@
   "disabledWallets": [
     "metamask",
     "trezor"
-  ]
+  ],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_enabled_features.json
+++ b/src/tests/json/chains/rinkeby_enabled_features.json
@@ -1,8 +1,8 @@
 {
   "chainId": "4",
   "chainName": "Rinkeby",
+  "shortName" : "rin",
   "l2": false,
-  "shortName": "rin",
   "description": "Random description",
   "rpcUri": {
     "authentication": "API_KEY_PATH",
@@ -22,12 +22,19 @@
     "logoUri": "https://test.token.image.url"
   },
   "theme": {
-    "textColor": "#fff",
-    "backgroundColor": "#000"
+    "textColor": "#ffffff",
+    "backgroundColor": "#000000"
   },
   "ensRegistryAddress": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-  "gasPrice": [],
+  "gasPrice": [
+    {
+      "type": "oracle",
+      "uri": "https://gaspriceoracle.com/",
+      "gasParameter": "average",
+      "gweiFactor": "10"
+    }
+  ],
   "recommendedMasterCopyVersion": "1.1.1",
   "disabledWallets": [],
-  "features": []
+  "features": ["Feature 1", "Feature 2"]
 }

--- a/src/tests/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/tests/json/chains/rinkeby_fixed_gas_price.json
@@ -33,5 +33,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/tests/json/chains/rinkeby_multiple_gas_price.json
@@ -39,5 +39,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
@@ -35,5 +35,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/tests/json/chains/rinkeby_rpc_no_auth.json
@@ -35,5 +35,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/tests/json/chains/rinkeby_unknown_gas_price.json
@@ -33,5 +33,6 @@
     }
   ],
   "recommendedMasterCopyVersion": "1.1.1",
-  "disabledWallets": []
+  "disabledWallets": [],
+  "features": []
 }

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -135,6 +135,8 @@ pub const CHAIN_INFO_RINKEBY_RPC_UNKNOWN_AUTHENTICATION: &str =
     include_str!("chains/rinkeby_rpc_auth_unknown.json");
 pub const CHAIN_INFO_RINKEBY_DISABLED_WALLETS: &str =
     include_str!("chains/rinkeby_disabled_wallets.json");
+pub const CHAIN_INFO_RINKEBY_ENABLED_FEATURES: &str =
+    include_str!("chains/rinkeby_enabled_features.json");
 
 pub const POLYGON_SAFE_APPS: &str = include_str!("safe_apps/polygon_safe_apps.json");
 


### PR DESCRIPTION
Closes #675 

- Add `features` to `ChainInfo`

```
GET /v1/chains/<chain_id>


{
  "chainId": <string>,
  "features": [<string>] // eg.: [ "ERC721", "SAFE_APPS"]
  ...
}
```