### PR TITLE
Improving test coverage for `InfoProvider`

### DIFF
--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -48,6 +48,7 @@ pub enum TokenType {
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct SafeInfo {
     pub address: String,
     pub nonce: u64,
@@ -60,9 +61,9 @@ pub struct SafeInfo {
     pub version: Option<String>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct SafeAppInfo {
     pub name: String,
     pub url: String,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,3 +2,6 @@ pub mod address_info;
 pub mod ext;
 pub mod fiat;
 pub mod info;
+
+#[cfg(test)]
+mod tests;

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -4,12 +4,13 @@ use mockall::predicate::eq;
 
 use crate::{
     cache::redis::create_service_cache,
-    cache::Cache,
+    cache::{Cache, MockCache},
     common::models::backend::chains::ChainInfo,
     config::chain_info_request_timeout,
     providers::info::{DefaultInfoProvider, InfoProvider},
     utils::{
         context::RequestContext,
+        errors::{ApiError, ErrorDetails},
         http_client::{HttpClient, MockHttpClient, Request, Response},
     },
 };
@@ -19,9 +20,10 @@ async fn default_info_provider_chain_info() {
     let expected =
         serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY).unwrap();
     let request_uri = config_uri!("/v1/chains/{}/", 4);
-    let mut mock_http_client = MockHttpClient::new();
     let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
 
+    let mut mock_http_client = MockHttpClient::new();
     let mut chain_request = Request::new(request_uri.clone());
     chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
     mock_http_client
@@ -49,10 +51,42 @@ async fn default_info_provider_chain_info() {
 }
 
 #[rocket::async_test]
-async fn default_info_provider_chain_info_in_mem_cache() {}
+async fn default_info_provider_chain_info_not_found() {
+    let expected = ApiError {
+        status: 404,
+        details: ErrorDetails {
+            code: 1337,
+            message: Some(String::from("Not found")),
+            arguments: None,
+            debug: None,
+        },
+    };
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
 
-#[rocket::async_test]
-async fn default_info_provider_chain_info_hits_redis_cache() {}
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                status_code: 404,
+                body: String::from("Not found"),
+            }))
+        });
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let info_provider = DefaultInfoProvider::new("4", &context);
 
-#[rocket::async_test]
-async fn default_info_provider_chain_info_not_found() {}
+    let actual = info_provider.chain_info().await;
+
+    assert_eq!(actual, Err(expected));
+}

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -1,19 +1,17 @@
-use std::{sync::Arc, time::Duration};
-
-use mockall::predicate::eq;
-
 use crate::{
     cache::redis::create_service_cache,
-    cache::{Cache, MockCache},
+    cache::Cache,
     common::models::backend::chains::ChainInfo,
-    config::chain_info_request_timeout,
-    providers::info::{DefaultInfoProvider, InfoProvider},
+    config::{chain_info_request_timeout, safe_info_request_timeout},
+    providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo},
     utils::{
         context::RequestContext,
         errors::{ApiError, ErrorDetails},
         http_client::{HttpClient, MockHttpClient, Request, Response},
     },
 };
+use mockall::predicate::eq;
+use std::{sync::Arc, time::Duration};
 
 #[rocket::async_test]
 async fn default_info_provider_chain_info() {
@@ -52,15 +50,6 @@ async fn default_info_provider_chain_info() {
 
 #[rocket::async_test]
 async fn default_info_provider_chain_info_not_found() {
-    let expected = ApiError {
-        status: 404,
-        details: ErrorDetails {
-            code: 1337,
-            message: Some(String::from("Not found")),
-            arguments: None,
-            debug: None,
-        },
-    };
     let request_uri = config_uri!("/v1/chains/{}/", 4);
     let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
     cache.invalidate_pattern("*");
@@ -84,9 +73,129 @@ async fn default_info_provider_chain_info_not_found() {
         &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
         &cache,
     );
+    let expected = ApiError {
+        status: 404,
+        details: ErrorDetails {
+            code: 1337,
+            message: Some(String::from("Not found")),
+            arguments: None,
+            debug: None,
+        },
+    };
     let info_provider = DefaultInfoProvider::new("4", &context);
 
     let actual = info_provider.chain_info().await;
+
+    assert_eq!(actual, Err(expected));
+}
+
+#[rocket::async_test]
+async fn default_info_provider_safe_info() {
+    let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_MODULES),
+                status_code: 200,
+            })
+        });
+
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = serde_json::from_str::<SafeInfo>(crate::tests::json::SAFE_WITH_MODULES)
+        .expect("SafeInfo deserialization issue");
+    let info_provider = DefaultInfoProvider::new("4", &context);
+
+    let actual = info_provider.safe_info(safe_address).await.unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[rocket::async_test]
+async fn default_info_provider_safe_info_not_found() {
+    let safe_address = "0x1230B3d59858296A31053C1b8562Ecf89A2f888b";
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                status_code: 404,
+                body: String::from("Not found"),
+            }))
+        });
+
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = ApiError {
+        status: 404,
+        details: ErrorDetails {
+            code: 1337,
+            message: Some(String::from("Not found")),
+            arguments: None,
+            debug: None,
+        },
+    };
+    let info_provider = DefaultInfoProvider::new("4", &context);
+
+    let actual = info_provider.safe_info(safe_address).await;
 
     assert_eq!(actual, Err(expected));
 }

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -1,0 +1,10 @@
+use rocket::local::asynchronous::Client;
+
+#[rocket::async_test]
+async fn default_info_provider_chain_info() {}
+
+#[rocket::async_test]
+async fn default_info_provider_chain_info_in_mem_cache() {}
+
+#[rocket::async_test]
+async fn default_info_provider_chain_info_not_found() {}

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -1,9 +1,9 @@
 use crate::{
     cache::redis::create_service_cache,
     cache::Cache,
-    common::models::backend::chains::ChainInfo,
-    config::{chain_info_request_timeout, safe_info_request_timeout},
-    providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo},
+    common::models::{backend::chains::ChainInfo, page::Page},
+    config::{chain_info_request_timeout, safe_info_request_timeout, token_info_request_timeout},
+    providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo, TokenInfo},
     utils::{
         context::RequestContext,
         errors::{ApiError, ErrorDetails},
@@ -198,4 +198,196 @@ async fn default_info_provider_safe_info_not_found() {
     let actual = info_provider.safe_info(safe_address).await;
 
     assert_eq!(actual, Err(expected));
+}
+
+#[rocket::async_test]
+async fn default_info_provider_token_info() {
+    let token_address = "0xD81F7D71ed570D121A1Ef9e3Bc0fc2bd6192De46";
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut token_request = Request::new(String::from(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+    ));
+    token_request.timeout(Duration::from_millis(token_info_request_timeout()));
+    let page_tokens: Page<TokenInfo> = Page {
+        next: None,
+        previous: None,
+        results: vec![
+            serde_json::from_str(crate::tests::json::TOKEN_BAT).expect("BAT token failure")
+        ],
+    };
+
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(token_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: serde_json::to_string(&page_tokens).expect("Token page failure"),
+                status_code: 200,
+            })
+        });
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = Ok(serde_json::from_str::<TokenInfo>(crate::tests::json::TOKEN_BAT).unwrap());
+
+    let info_provider = DefaultInfoProvider::new("4", &context);
+    let actual = info_provider.token_info(token_address).await;
+
+    assert_eq!(expected, actual);
+}
+
+#[rocket::async_test]
+async fn default_info_provider_token_info_request_failure() {
+    let token_address = "0xD81F7D71ed570D121A1Ef9e3Bc0fc2bd6192De46";
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut token_request = Request::new(String::from(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+    ));
+    token_request.timeout(Duration::from_millis(token_info_request_timeout()));
+
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(token_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                status_code: 404,
+                body: String::from("Not found"),
+            }))
+        });
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = Err(ApiError::new_from_message_with_code(
+        404,
+        String::from("Not found"),
+    ));
+
+    let info_provider = DefaultInfoProvider::new("4", &context);
+    let actual = info_provider.token_info(token_address).await;
+
+    assert_eq!(expected, actual);
+}
+
+#[rocket::async_test]
+async fn default_info_provider_token_info_not_found_in_cache() {
+    let token_address = "0xD81F7D71ed570D121A1Ef9e3Bc0fc2bd6192De41";
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut token_request = Request::new(String::from(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+    ));
+    token_request.timeout(Duration::from_millis(token_info_request_timeout()));
+    let page_tokens: Page<TokenInfo> = Page {
+        next: None,
+        previous: None,
+        results: vec![
+            serde_json::from_str(crate::tests::json::TOKEN_BAT).expect("BAT token failure")
+        ],
+    };
+
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(token_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: serde_json::to_string(&page_tokens).expect("Token page failure"),
+                status_code: 200,
+            })
+        });
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = Err(ApiError::new_from_message("Could not generate value"));
+
+    let info_provider = DefaultInfoProvider::new("4", &context);
+    let actual = info_provider.token_info(token_address).await;
+
+    assert_eq!(expected, actual);
+}
+
+#[rocket::async_test]
+async fn default_info_provider_token_info_address_0x0() {
+    let token_address = "0x0000000000000000000000000000000000000000";
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+    cache.invalidate_pattern("*");
+
+    let mut mock_http_client = MockHttpClient::new();
+
+    let context = RequestContext::new(
+        String::from(""),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = Err(ApiError::new_from_message_with_code(
+        500,
+        String::from("Token Address is 0x0"),
+    ));
+
+    let info_provider = DefaultInfoProvider::new("4", &context);
+    let actual = info_provider.token_info(token_address).await;
+
+    assert_eq!(expected, actual);
 }

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -1,10 +1,58 @@
-use rocket::local::asynchronous::Client;
+use std::{sync::Arc, time::Duration};
+
+use mockall::predicate::eq;
+
+use crate::{
+    cache::redis::create_service_cache,
+    cache::Cache,
+    common::models::backend::chains::ChainInfo,
+    config::chain_info_request_timeout,
+    providers::info::{DefaultInfoProvider, InfoProvider},
+    utils::{
+        context::RequestContext,
+        http_client::{HttpClient, MockHttpClient, Request, Response},
+    },
+};
 
 #[rocket::async_test]
-async fn default_info_provider_chain_info() {}
+async fn default_info_provider_chain_info() {
+    let expected =
+        serde_json::from_str::<ChainInfo>(crate::tests::json::CHAIN_INFO_RINKEBY).unwrap();
+    let request_uri = config_uri!("/v1/chains/{}/", 4);
+    let mut mock_http_client = MockHttpClient::new();
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+    let context = RequestContext::new(
+        String::from(&request_uri),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+
+    let info_provider = DefaultInfoProvider::new("4", &context);
+
+    let actual = info_provider.chain_info().await.unwrap();
+
+    assert_eq!(actual, expected)
+}
 
 #[rocket::async_test]
 async fn default_info_provider_chain_info_in_mem_cache() {}
+
+#[rocket::async_test]
+async fn default_info_provider_chain_info_hits_redis_cache() {}
 
 #[rocket::async_test]
 async fn default_info_provider_chain_info_not_found() {}

--- a/src/providers/tests/mod.rs
+++ b/src/providers/tests/mod.rs
@@ -1,0 +1,1 @@
+mod info;

--- a/src/routes/transactions/converters/safe_app_info.rs
+++ b/src/routes/transactions/converters/safe_app_info.rs
@@ -6,6 +6,7 @@ pub async fn safe_app_info_from(
     info_provider: &(impl InfoProvider + Sync),
 ) -> Option<SafeAppInfo> {
     let origin_internal = serde_json::from_str::<OriginInternal>(origin).ok()?;
+    log::error!("{:#?}", &origin_internal);
     info_provider
         .safe_app_info(
             &origin_internal

--- a/src/routes/transactions/models/details.rs
+++ b/src/routes/transactions/models/details.rs
@@ -218,9 +218,9 @@ use std::collections::HashMap;
 /// }
 /// ```
 /// </details>
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct TransactionDetails {
     pub tx_id: String,
     pub executed_at: Option<i64>,
@@ -233,17 +233,17 @@ pub struct TransactionDetails {
     pub safe_app_info: Option<SafeAppInfo>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub enum DetailedExecutionInfo {
     Multisig(MultisigExecutionDetails),
     Module(ModuleExecutionDetails),
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct MultisigExecutionDetails {
     pub submitted_at: i64,
     pub nonce: u64,
@@ -264,25 +264,25 @@ pub struct MultisigExecutionDetails {
     pub gas_token_info: Option<TokenInfo>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct MultisigConfirmation {
     pub signer: AddressEx,
     pub signature: Option<String>,
     pub submitted_at: i64,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct ModuleExecutionDetails {
     pub address: AddressEx,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(test, derive(serde::Deserialize))]
+#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
 pub struct TransactionData {
     pub hex_data: Option<String>,
     pub data_decoded: Option<DataDecoded>,

--- a/src/routes/transactions/models/summary.rs
+++ b/src/routes/transactions/models/summary.rs
@@ -122,8 +122,9 @@ use serde::Serialize;
 /// ```
 ///
 /// </details>
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct TransactionSummary {
     pub id: String,
     pub timestamp: i64,
@@ -135,15 +136,17 @@ pub struct TransactionSummary {
     pub safe_app_info: Option<SafeAppInfo>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum ExecutionInfo {
     Multisig(MultisigExecutionInfo),
     Module(ModuleExecutionInfo),
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct MultisigExecutionInfo {
     pub nonce: u64,
     pub confirmations_required: u64,
@@ -152,15 +155,17 @@ pub struct MultisigExecutionInfo {
     pub missing_signers: Option<Vec<AddressEx>>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct ModuleExecutionInfo {
     pub address: AddressEx,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
 #[serde(tag = "type")]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum TransactionListItem {
     #[serde(rename_all = "camelCase")]
     Transaction {
@@ -178,7 +183,8 @@ pub enum TransactionListItem {
     },
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Label {
     Next,
     Queued,

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -143,5 +143,6 @@ pub const CHAIN_INFO_RINKEBY_ENABLED_FEATURES: &str =
     include_str!("chains/rinkeby_enabled_features.json");
 
 pub const POLYGON_SAFE_APPS: &str = include_str!("safe_apps/polygon_safe_apps.json");
+pub const UNISWAP_SAFE_APP_MANIFEST: &str = include_str!("safe_apps/uniswap_manifest.json");
 
 pub const POLYGON_MASTER_COPIES: &str = include_str!("master_copies/polygon_master_copies.json");

--- a/src/tests/json/safe_apps/uniswap_manifest.json
+++ b/src/tests/json/safe_apps/uniswap_manifest.json
@@ -1,0 +1,30 @@
+{
+    "background_color": "#fff",
+    "display": "standalone",
+    "homepage_url": "https://app.uniswap.org",
+    "providedBy": {
+        "name": "Uniswap",
+        "url": "https://uniswap.org"
+    },
+    "icons": [
+        {
+            "src": "./images/192x192_App_Icon.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any maskable"
+        },
+        {
+            "src": "./images/512x512_App_Icon.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any maskable"
+        }
+    ],
+    "orientation": "portrait",
+    "name": "Uniswap",
+    "description": "Swap or provide liquidity on the Uniswap Protocol",
+    "iconPath": "./images/256x256_App_Icon_Pink.svg",
+    "short_name": "Uniswap",
+    "start_url": ".",
+    "theme_color": "#ff007a"
+}

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -19,6 +19,21 @@ impl RequestContext {
     pub fn cache(&self) -> Arc<dyn Cache> {
         self.cache.clone()
     }
+
+    #[cfg(test)]
+    pub fn new(
+        request_id: String,
+        host: String,
+        http_client: &Arc<dyn HttpClient>,
+        cache: &Arc<dyn Cache>,
+    ) -> Self {
+        RequestContext {
+            request_id,
+            host,
+            http_client: http_client.clone(),
+            cache: cache.clone(),
+        }
+    }
 }
 
 #[rocket::async_trait]


### PR DESCRIPTION
Closes #689 

Tested coverage for:
- `TokenInfo`
- `SafeInfo`
- `SafeAppInfo`
- `ChainInfo`