### PR TITLE
Add safe_apps_rpc_uri to ChainInfo

### DIFF
--- a/src/common/models/backend/chains.rs
+++ b/src/common/models/backend/chains.rs
@@ -12,6 +12,7 @@ pub struct ChainInfo {
     pub l2: bool,
     pub description: String,
     pub rpc_uri: RpcUri,
+    pub safe_apps_rpc_uri: RpcUri,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -26,6 +26,16 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 },
                 value: chain_info.rpc_uri.value,
             },
+            safe_apps_rpc_uri: ServiceRpcUri {
+                authentication: match chain_info.safe_apps_rpc_uri.authentication {
+                    RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
+                    RpcAuthentication::NoAuthentication => {
+                        ServiceRpcAuthentication::NoAuthentication
+                    }
+                    RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
+                },
+                value: chain_info.safe_apps_rpc_uri.value,
+            },
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -11,6 +11,7 @@ pub struct ChainInfo {
     pub l2: bool,
     pub description: String,
     pub rpc_uri: RpcUri,
+    pub safe_apps_rpc_uri: RpcUri,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/routes/chains/tests/chains.rs
+++ b/src/routes/chains/tests/chains.rs
@@ -23,6 +23,10 @@ fn chain_info_json() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -70,6 +74,10 @@ fn chain_info_json_with_fixed_gas_price() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -116,6 +124,10 @@ fn chain_info_json_with_no_gas_price() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -159,6 +171,10 @@ fn chain_info_json_with_multiple_gas_price() {
         rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
+        },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
         },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -214,6 +230,10 @@ fn chain_info_json_with_unknown_gas_price_type() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -257,6 +277,10 @@ fn chain_info_json_with_no_rpc_authentication() {
         rpc_uri: RpcUri {
             authentication: RpcAuthentication::NoAuthentication,
             value: "https://someurl.com/rpc".to_string(),
+        },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
         },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -307,6 +331,10 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             authentication: RpcAuthentication::Unknown,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -353,6 +381,10 @@ fn chain_info_json_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -398,6 +430,10 @@ fn unknown_gas_price_type_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -439,6 +475,10 @@ fn no_authentication_to_service_chain_info() {
         rpc_uri: ServiceRpcUri {
             authentication: ServiceRpcAuthentication::NoAuthentication,
             value: "https://someurl.com/rpc".to_string(),
+        },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
         },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -487,6 +527,10 @@ fn unknown_authentication_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::Unknown,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -534,6 +578,10 @@ fn disabled_wallets_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
         },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -579,6 +627,10 @@ fn features_to_service_chain_info() {
         rpc_uri: ServiceRpcUri {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc".to_string(),
+        },
+        safe_apps_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/apps".to_string(),
         },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -24,6 +24,10 @@ async fn core_uri_success_with_params_prod() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
@@ -76,6 +80,10 @@ async fn core_uri_success_without_params_prod() {
         l2: false,
         description: "Random description".to_string(),
         rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        safe_apps_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
@@ -134,6 +142,10 @@ async fn core_uri_success_with_params_local() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
+        safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
@@ -186,6 +198,10 @@ async fn core_uri_success_without_params_local() {
         l2: false,
         description: "Random description".to_string(),
         rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        safe_apps_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },

--- a/src/tests/json/chains/rinkeby.json
+++ b/src/tests/json/chains/rinkeby.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_disabled_wallets.json
+++ b/src/tests/json/chains/rinkeby_disabled_wallets.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_enabled_features.json
+++ b/src/tests/json/chains/rinkeby_enabled_features.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/tests/json/chains/rinkeby_fixed_gas_price.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/tests/json/chains/rinkeby_multiple_gas_price.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_no_gas_price.json
+++ b/src/tests/json/chains/rinkeby_no_gas_price.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
@@ -8,6 +8,10 @@
     "authentication": "SOME_RANDOM_AUTH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/tests/json/chains/rinkeby_rpc_no_auth.json
@@ -8,6 +8,10 @@
     "authentication": "NO_AUTHENTICATION",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/tests/json/chains/rinkeby_unknown_gas_price.json
@@ -8,6 +8,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc"
   },
+  "safeAppsRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/apps"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",


### PR DESCRIPTION
- `safe_apps_rpc_uri` represents a different RPC url that can be used by the clients in the context of `safe-apps`
-  It was already part of the `/api/v1/chains` of the `safe-config-service` but was never exposed to the clients via the `safe-client-gateway`