### PR TITLE
Documentation fix for `post_transaction`

### DIFF
--- a/src/routes/transactions/routes.rs
+++ b/src/routes/transactions/routes.rs
@@ -195,7 +195,7 @@ pub async fn get_transactions_queued(
 
 /**
  * `/v1/chains/<chain_id>/transactions/<safe_address>/propose` <br />
- * No return value
+ * returns [TransactionDetails](crate::routes::transactions::models::details::TransactionDetails)
  *
  * # Transaction Proposal
  *


### PR DESCRIPTION
Please ignore the branch name. It is unrelated to this fix.