### PR TITLE
Fix balances route for balances_v2

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -78,7 +78,7 @@ pub fn balances_cache_duration() -> usize {
     env_with_default("BALANCES_REQUEST_CACHE_DURATION", 60 * 1000)
 }
 
-pub fn balances_core_cache_duration() -> usize {
+pub fn balances_core_request_cache_duration() -> usize {
     env_with_default("BALANCES_CORE_REQUEST_CACHE_DURATION", indefinite_timeout())
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -78,6 +78,10 @@ pub fn balances_cache_duration() -> usize {
     env_with_default("BALANCES_REQUEST_CACHE_DURATION", 60 * 1000)
 }
 
+pub fn balances_core_cache_duration() -> usize {
+    env_with_default("BALANCES_CORE_REQUEST_CACHE_DURATION", indefinite_timeout())
+}
+
 pub fn safe_app_manifest_cache_duration() -> usize {
     env_with_default("SAFE_APP_MANIFEST_CACHE_DURATION", indefinite_timeout())
 }
@@ -91,7 +95,7 @@ pub fn safe_apps_cache_duration() -> usize {
 }
 
 pub fn token_price_cache_duration() -> usize {
-    env_with_default("TOKEN_PRICE_CACHE_DURATION", 1) // set to negligible value
+    env_with_default("TOKEN_PRICE_CACHE_DURATION", 10 * 1000)
 }
 
 // REQUEST TIMEOUTS

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -63,6 +63,11 @@ fn build_usize_test_cases() -> Vec<USizeEnvValue> {
             env_key: String::from("OWNERS_FOR_SAFES_CACHE_DURATION"),
             generator: Box::new(super::owners_for_safes_cache_duration),
         },
+        USizeEnvValue {
+            expected_default: 60 * 60 * 1000,
+            env_key: String::from("BALANCES_CORE_REQUEST_CACHE_DURATION"),
+            generator: Box::new(super::balances_core_request_cache_duration),
+        },
     ]
 }
 

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -68,6 +68,11 @@ fn build_usize_test_cases() -> Vec<USizeEnvValue> {
             env_key: String::from("BALANCES_CORE_REQUEST_CACHE_DURATION"),
             generator: Box::new(super::balances_core_request_cache_duration),
         },
+        USizeEnvValue {
+            expected_default: 10 * 1000,
+            env_key: String::from("TOKEN_PRICE_CACHE_DURATION"),
+            generator: Box::new(super::token_price_cache_duration),
+        },
     ]
 }
 

--- a/src/routes/balances/handlers_v2.rs
+++ b/src/routes/balances/handlers_v2.rs
@@ -6,7 +6,7 @@ use crate::common::models::backend::balances_v2::Balance as BalanceDto;
 use crate::common::models::backend::balances_v2::TokenPrice as BackendTokenPrice;
 use crate::common::models::backend::chains::NativeCurrency;
 use crate::config::{
-    balances_cache_duration, balances_core_cache_duration, balances_request_timeout,
+    balances_core_request_cache_duration, balances_request_timeout,
     concurrent_balance_token_requests, token_price_cache_duration,
 };
 use crate::providers::fiat::FiatInfoProvider;
@@ -34,7 +34,7 @@ pub async fn balances(
     )?;
 
     let body = RequestCached::new_from_context(url, context)
-        .cache_duration(balances_core_cache_duration())
+        .cache_duration(balances_core_request_cache_duration())
         .request_timeout(balances_request_timeout())
         .execute()
         .await?;

--- a/src/routes/balances/handlers_v2.rs
+++ b/src/routes/balances/handlers_v2.rs
@@ -1,18 +1,19 @@
+use bigdecimal::BigDecimal;
+use rocket::futures::{stream, StreamExt};
+
 use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::balances_v2::Balance as BalanceDto;
 use crate::common::models::backend::balances_v2::TokenPrice as BackendTokenPrice;
 use crate::common::models::backend::chains::NativeCurrency;
 use crate::config::{
-    balances_cache_duration, balances_request_timeout, concurrent_balance_token_requests,
-    token_price_cache_duration,
+    balances_cache_duration, balances_core_cache_duration, balances_request_timeout,
+    concurrent_balance_token_requests, token_price_cache_duration,
 };
 use crate::providers::fiat::FiatInfoProvider;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::balances::models::{Balance, Balances, TokenPrice};
 use crate::utils::context::RequestContext;
 use crate::utils::errors::ApiResult;
-use bigdecimal::BigDecimal;
-use rocket::futures::{stream, StreamExt};
 
 pub async fn balances(
     context: &RequestContext,
@@ -26,14 +27,14 @@ pub async fn balances(
     let fiat_info_provider = FiatInfoProvider::new(context);
     let url = core_uri!(
         info_provider,
-        "/v1/safes/{}/balances/usd/?trusted={}&exclude_spam={}",
+        "/v1/safes/{}/balances/?trusted={}&exclude_spam={}",
         safe_address,
         trusted,
         exclude_spam
     )?;
 
     let body = RequestCached::new_from_context(url, context)
-        .cache_duration(balances_cache_duration())
+        .cache_duration(balances_core_cache_duration())
         .request_timeout(balances_request_timeout())
         .execute()
         .await?;


### PR DESCRIPTION
- Use `/v1/safes/{}/balances/` instead of `/v1/safes/{}/balances/usd/` for balances. This was one of the main purposes of the new feature but it was still using the old transaction service route
- Balance requests to the core services now follow `BALANCES_CORE_REQUEST_CACHE_DURATION` which is set to 1 hour by default
- Token requests to the core services are now cached for 10 seconds