### PR TITLE
Add public_rpc_uri to ChainInfo

### DIFF
--- a/src/common/models/backend/chains.rs
+++ b/src/common/models/backend/chains.rs
@@ -13,6 +13,7 @@ pub struct ChainInfo {
     pub description: String,
     pub rpc_uri: RpcUri,
     pub safe_apps_rpc_uri: RpcUri,
+    pub public_rpc_uri: RpcUri,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -36,6 +36,16 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 },
                 value: chain_info.safe_apps_rpc_uri.value,
             },
+            public_rpc_uri: ServiceRpcUri {
+                authentication: match chain_info.public_rpc_uri.authentication {
+                    RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
+                    RpcAuthentication::NoAuthentication => {
+                        ServiceRpcAuthentication::NoAuthentication
+                    }
+                    RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
+                },
+                value: chain_info.public_rpc_uri.value,
+            },
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -16,9 +16,9 @@ impl From<BackendChainInfo> for ServiceChainInfo {
             short_name: chain_info.short_name,
             l2: chain_info.l2,
             description: chain_info.description,
-            rpc_uri: ServiceRpcUri::from(chain_info.rpc_uri),
-            safe_apps_rpc_uri: ServiceRpcUri::from(chain_info.safe_apps_rpc_uri),
-            public_rpc_uri: ServiceRpcUri::from(chain_info.public_rpc_uri),
+            rpc_uri: chain_info.rpc_uri.into(),
+            safe_apps_rpc_uri: chain_info.safe_apps_rpc_uri.into(),
+            public_rpc_uri: chain_info.public_rpc_uri.into(),
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,

--- a/src/routes/chains/converters.rs
+++ b/src/routes/chains/converters.rs
@@ -1,5 +1,5 @@
 use crate::common::models::backend::chains::{
-    ChainInfo as BackendChainInfo, GasPrice, RpcAuthentication,
+    ChainInfo as BackendChainInfo, GasPrice, RpcAuthentication, RpcUri as BackendRpcUri,
 };
 use crate::routes::chains::models::{
     BlockExplorerUriTemplate as ServiceBlockExplorerUriTemplate, ChainInfo as ServiceChainInfo,
@@ -16,36 +16,9 @@ impl From<BackendChainInfo> for ServiceChainInfo {
             short_name: chain_info.short_name,
             l2: chain_info.l2,
             description: chain_info.description,
-            rpc_uri: ServiceRpcUri {
-                authentication: match chain_info.rpc_uri.authentication {
-                    RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
-                    RpcAuthentication::NoAuthentication => {
-                        ServiceRpcAuthentication::NoAuthentication
-                    }
-                    RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
-                },
-                value: chain_info.rpc_uri.value,
-            },
-            safe_apps_rpc_uri: ServiceRpcUri {
-                authentication: match chain_info.safe_apps_rpc_uri.authentication {
-                    RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
-                    RpcAuthentication::NoAuthentication => {
-                        ServiceRpcAuthentication::NoAuthentication
-                    }
-                    RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
-                },
-                value: chain_info.safe_apps_rpc_uri.value,
-            },
-            public_rpc_uri: ServiceRpcUri {
-                authentication: match chain_info.public_rpc_uri.authentication {
-                    RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
-                    RpcAuthentication::NoAuthentication => {
-                        ServiceRpcAuthentication::NoAuthentication
-                    }
-                    RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
-                },
-                value: chain_info.public_rpc_uri.value,
-            },
+            rpc_uri: ServiceRpcUri::from(chain_info.rpc_uri),
+            safe_apps_rpc_uri: ServiceRpcUri::from(chain_info.safe_apps_rpc_uri),
+            public_rpc_uri: ServiceRpcUri::from(chain_info.public_rpc_uri),
             block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
                 address: chain_info.block_explorer_uri_template.address,
                 tx_hash: chain_info.block_explorer_uri_template.tx_hash,
@@ -83,6 +56,19 @@ impl From<BackendChainInfo> for ServiceChainInfo {
                 .collect::<Vec<ServiceGasPrice>>(),
             disabled_wallets: chain_info.disabled_wallets,
             features: chain_info.features,
+        }
+    }
+}
+
+impl From<BackendRpcUri> for ServiceRpcUri {
+    fn from(rpc_uri: BackendRpcUri) -> Self {
+        ServiceRpcUri {
+            authentication: match rpc_uri.authentication {
+                RpcAuthentication::ApiKeyPath => ServiceRpcAuthentication::ApiKeyPath,
+                RpcAuthentication::NoAuthentication => ServiceRpcAuthentication::NoAuthentication,
+                RpcAuthentication::Unknown => ServiceRpcAuthentication::Unknown,
+            },
+            value: rpc_uri.value,
         }
     }
 }

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -12,6 +12,7 @@ pub struct ChainInfo {
     pub description: String,
     pub rpc_uri: RpcUri,
     pub safe_apps_rpc_uri: RpcUri,
+    pub public_rpc_uri: RpcUri,
     pub block_explorer_uri_template: BlockExplorerUriTemplate,
     pub native_currency: NativeCurrency,
     pub theme: Theme,

--- a/src/routes/chains/tests/chains.rs
+++ b/src/routes/chains/tests/chains.rs
@@ -27,6 +27,10 @@ fn chain_info_json() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -78,6 +82,10 @@ fn chain_info_json_with_fixed_gas_price() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -128,6 +136,10 @@ fn chain_info_json_with_no_gas_price() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -175,6 +187,10 @@ fn chain_info_json_with_multiple_gas_price() {
         safe_apps_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
+        },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
         },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -234,6 +250,10 @@ fn chain_info_json_with_unknown_gas_price_type() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -281,6 +301,10 @@ fn chain_info_json_with_no_rpc_authentication() {
         safe_apps_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
+        },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
         },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -335,6 +359,10 @@ fn chain_info_json_with_unknown_rpc_authentication() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -385,6 +413,10 @@ fn chain_info_json_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -434,6 +466,10 @@ fn unknown_gas_price_type_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -479,6 +515,10 @@ fn no_authentication_to_service_chain_info() {
         safe_apps_rpc_uri: ServiceRpcUri {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
+        },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
         },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
@@ -531,6 +571,10 @@ fn unknown_authentication_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -582,6 +626,10 @@ fn disabled_wallets_to_service_chain_info() {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
         },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
+        },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),
             tx_hash: "https://blockexplorer.com/{{txHash}}".to_string(),
@@ -631,6 +679,10 @@ fn features_to_service_chain_info() {
         safe_apps_rpc_uri: ServiceRpcUri {
             authentication: ServiceRpcAuthentication::ApiKeyPath,
             value: "https://someurl.com/rpc/apps".to_string(),
+        },
+        public_rpc_uri: ServiceRpcUri {
+            authentication: ServiceRpcAuthentication::ApiKeyPath,
+            value: "https://someurl.com/rpc/public".to_string(),
         },
         block_explorer_uri_template: ServiceBlockExplorerUriTemplate {
             address: "https://blockexplorer.com/{{address}}".to_string(),

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -28,6 +28,10 @@ async fn core_uri_success_with_params_prod() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
@@ -84,6 +88,10 @@ async fn core_uri_success_without_params_prod() {
             value: "".to_string(),
         },
         safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        public_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
@@ -146,6 +154,10 @@ async fn core_uri_success_with_params_local() {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },
+        public_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
         block_explorer_uri_template: BlockExplorerUriTemplate {
             address: "".to_string(),
             tx_hash: "".to_string(),
@@ -202,6 +214,10 @@ async fn core_uri_success_without_params_local() {
             value: "".to_string(),
         },
         safe_apps_rpc_uri: RpcUri {
+            authentication: RpcAuthentication::ApiKeyPath,
+            value: "".to_string(),
+        },
+        public_rpc_uri: RpcUri {
             authentication: RpcAuthentication::ApiKeyPath,
             value: "".to_string(),
         },

--- a/src/tests/json/chains/polygon.json
+++ b/src/tests/json/chains/polygon.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://polygon-mainnet.infura.io/v3/"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://polygon-mainnet.infura.io/v3/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://polygonscan.com/address/{{address}}",
     "txHash": "https://polygonscan.com/tx/{{txHash}}",

--- a/src/tests/json/chains/rinkeby.json
+++ b/src/tests/json/chains/rinkeby.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_disabled_wallets.json
+++ b/src/tests/json/chains/rinkeby_disabled_wallets.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_enabled_features.json
+++ b/src/tests/json/chains/rinkeby_enabled_features.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_fixed_gas_price.json
+++ b/src/tests/json/chains/rinkeby_fixed_gas_price.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_multiple_gas_price.json
+++ b/src/tests/json/chains/rinkeby_multiple_gas_price.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_no_gas_price.json
+++ b/src/tests/json/chains/rinkeby_no_gas_price.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
+++ b/src/tests/json/chains/rinkeby_rpc_auth_unknown.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_rpc_no_auth.json
+++ b/src/tests/json/chains/rinkeby_rpc_no_auth.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",

--- a/src/tests/json/chains/rinkeby_unknown_gas_price.json
+++ b/src/tests/json/chains/rinkeby_unknown_gas_price.json
@@ -12,6 +12,10 @@
     "authentication": "API_KEY_PATH",
     "value": "https://someurl.com/rpc/apps"
   },
+  "publicRpcUri": {
+    "authentication": "API_KEY_PATH",
+    "value": "https://someurl.com/rpc/public"
+  },
   "blockExplorerUriTemplate": {
     "address": "https://blockexplorer.com/{{address}}",
     "txHash": "https://blockexplorer.com/{{txHash}}",


### PR DESCRIPTION
See https://github.com/gnosis/safe-config-service/issues/324 for more details

- Add `public_rpc_uri` to `ChainInfo` – this field represents a public RPC URI that can be set with external frameworks/wallets (eg.: metamask)
