### PR TITLE
Set broken_intra_doc_links linter to level deny

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 extern crate dotenv;
 extern crate log;


### PR DESCRIPTION
- Set `broken_intra_doc_links` to level `deny` – see https://doc.rust-lang.org/beta/rustdoc/lints.html#broken_intra_doc_links
- This makes the build return an error if there's a broken link in the docs