### PR TITLE
Delegate `DELETE` endpoints missing trailing `/` for core service request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "3.13.0"
+version = "3.13.1"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
 edition = "2018"
 

--- a/src/routes/delegates/handlers.rs
+++ b/src/routes/delegates/handlers.rs
@@ -59,7 +59,7 @@ pub async fn delete_delegate(
     delegate_delete: DelegateDelete,
 ) -> ApiResult<()> {
     let info_provider = DefaultInfoProvider::new(&chain_id, &context);
-    let url = core_uri!(info_provider, "/v1/delegates/{}", delegate_address)?;
+    let url = core_uri!(info_provider, "/v1/delegates/{}/", delegate_address)?;
 
     let request = {
         let mut request = Request::new(url);
@@ -81,7 +81,7 @@ pub async fn delete_safe_delegate(
     let info_provider = DefaultInfoProvider::new(&chain_id, &context);
     let url = core_uri!(
         info_provider,
-        "/v1/safes/{}/delegates/{}",
+        "/v1/safes/{}/delegates/{}/",
         safe_address,
         delegate_address
     )?;


### PR DESCRIPTION
Closes #741 

Missing trailing `/` for delete request to the core services.