### PR TITLE
Atempt http error deserialization

### DIFF
--- a/src/cache/tests/cache_op_executors.rs
+++ b/src/cache/tests/cache_op_executors.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use crate::cache::cache_operations::RequestCached;
+use crate::cache::redis::create_service_cache;
+use crate::cache::Cache;
+use crate::utils::context::RequestContext;
+use crate::utils::errors::{ApiError, ErrorDetails};
+use crate::utils::http_client::{HttpClient, MockHttpClient, Response};
+use serde_json::json;
+
+#[rocket::async_test]
+async fn error_from_backend_deserialization() {
+    let request_uri = "some.url";
+    let error_json = json!({
+        "code": 1,
+        "message": "Checksum address validation failed",
+        "arguments": [
+            "0xD6f5Bef6bb4acD235CF85c0ce196316d10785d67"
+        ]
+    });
+
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client.expect_get().times(1).returning(move |_| {
+        Err(ApiError::from_http_response(&Response {
+            body: error_json.to_string(),
+            status_code: 422,
+        }))
+    });
+    let cache = Arc::new(create_service_cache()) as Arc<dyn Cache>;
+
+    let context = RequestContext::setup_for_test(
+        String::from(request_uri),
+        "host".to_string(),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &cache,
+    );
+    let expected = Err(ApiError::new(
+        422,
+        serde_json::from_value::<ErrorDetails>(json!({
+            "code": 1,
+            "message": "Checksum address validation failed",
+            "arguments": [
+                "0xD6f5Bef6bb4acD235CF85c0ce196316d10785d67"
+            ]
+        }))
+        .unwrap(),
+    ));
+
+    let request = RequestCached::new_from_context(String::from(request_uri), &context);
+    let actual = request.execute().await;
+
+    assert_eq!(expected, actual);
+}

--- a/src/cache/tests/cache_op_executors.rs
+++ b/src/cache/tests/cache_op_executors.rs
@@ -54,7 +54,8 @@ async fn error_from_backend_deserialization() {
 
 #[rocket::async_test]
 async fn error_from_backend_deserialization_unknown_json_struct() {
-    // we've changed the json type to string for the sake of creating a synthetic API breaking change
+    // we've changed the json type of "code" to string,
+    // for the sake of creating a synthetic API breaking change
     let request_uri = "some.url";
     let error_json = json!({
         "code": "1",

--- a/src/cache/tests/mod.rs
+++ b/src/cache/tests/mod.rs
@@ -1,2 +1,3 @@
 mod cache_inner;
+mod cache_op_executors;
 mod cache_operations;

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -85,7 +85,7 @@ impl ApiError {
         )
     }
 
-    fn new(status_code: u16, message: ErrorDetails) -> Self {
+    pub fn new(status_code: u16, message: ErrorDetails) -> Self {
         Self {
             status: status_code,
             details: message,


### PR DESCRIPTION
Closes #745 

The issue was that we were storing in the cache the error json in the body of the request to the backend services, while forwarding the error by just passing the same body as a flat string. 

This change introduces the following:
- We attempt to deserialize into the error structure we know from the core services (`ErrorDetails`)
- if the error contains a structure we don't know, we revert to the old behaviour
- I added a tests to cover both branches
