### PR TITLE
Added chain dependant hook update endpoint

### DIFF
--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -17,18 +17,15 @@ pub fn update(context: RequestContext, token: String, update: Json<Payload>) -> 
 #[post(
     "/v1/chains/<chain_id>/hook/update/<token>",
     format = "json",
-    data = "<update>"
+    data = "<payload>"
 )]
 pub fn post_hook_update(
     context: RequestContext,
     chain_id: String,
     token: String,
-    update: Json<Payload>,
+    payload: Json<Payload>,
 ) -> ApiResult<()> {
-    if token != webhook_token() {
-        bail!("Invalid token");
-    }
-    invalidate_caches(context.cache(), &update)
+    update(context, token, payload)
 }
 
 #[post("/v1/flush/<token>", format = "json", data = "<invalidation_pattern>")]

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -14,6 +14,23 @@ pub fn update(context: RequestContext, token: String, update: Json<Payload>) -> 
     invalidate_caches(context.cache(), &update)
 }
 
+#[post(
+    "/v1/chains/<chain_id>/hook/update/<token>",
+    format = "json",
+    data = "<update>"
+)]
+pub fn post_hook_update(
+    context: RequestContext,
+    chain_id: String,
+    token: String,
+    update: Json<Payload>,
+) -> ApiResult<()> {
+    if token != webhook_token() {
+        bail!("Invalid token");
+    }
+    invalidate_caches(context.cache(), &update)
+}
+
 #[post("/v1/flush/<token>", format = "json", data = "<invalidation_pattern>")]
 pub fn flush(
     context: RequestContext,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -65,6 +65,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::routes::post_transaction,
         transactions::routes::post_confirmation,
         hooks::routes::update,
+        hooks::routes::post_hook_update,
         hooks::routes::flush,
         health::routes::health
     ]


### PR DESCRIPTION
Closes #749 

Note: we were never consuming the `chainId` returned in the `Payload` from the core services, as we are simply invalidating safes across chains. 

If we have the `chain_id` we can attempt to rebuild the request URL and thusly the cache key, although this change would be much more involved.