### PR TITLE
Closes #757: Fix wrong `latestNonce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "3.13.2"
+version = "3.13.3"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "3.13.2"
+version = "3.13.3"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
 edition = "2018"
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -58,6 +58,7 @@ pub fn active_routes() -> Vec<Route> {
         safes::routes::get_safe_info,
         safes::routes::get_owners,
         safes::routes::post_safe_gas_estimation,
+        safes::routes::post_safe_gas_estimation_v2,
         safe_apps::routes::get_safe_apps,
         transactions::routes::get_transactions,
         transactions::routes::get_transactions_history,

--- a/src/routes/safes/handlers/estimations.rs
+++ b/src/routes/safes/handlers/estimations.rs
@@ -31,9 +31,7 @@ pub async fn estimate_safe_tx_gas(
     )?;
     let current_nonce = info_provider.safe_info(safe_address).await?.nonce;
 
-    let last_known_nonce =
-        fetch_latest_nonce(context.http_client(), latest_multisig_tx_url).await?;
-    let latest_nonce = max(current_nonce, last_known_nonce);
+    let latest_nonce = fetch_latest_nonce(context.http_client(), latest_multisig_tx_url).await?;
     let safe_tx_gas = fetch_estimation(
         context.http_client(),
         estimation_url,

--- a/src/routes/safes/handlers/estimations.rs
+++ b/src/routes/safes/handlers/estimations.rs
@@ -6,32 +6,37 @@ use crate::common::models::backend::transactions::{
 };
 use crate::common::models::page::Page;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
-use crate::routes::safes::models::{SafeTransactionEstimation, SafeTransactionEstimationRequest};
+use crate::routes::safes::models::{
+    SafeTransactionEstimation, SafeTransactionEstimationRequest, SafeTransactionEstimationV2,
+};
 use crate::utils::context::RequestContext;
 use crate::utils::errors::ApiResult;
 use crate::utils::http_client::{HttpClient, Request};
 use std::cmp::max;
 
-pub async fn estimate_safe_tx_gas(
+async fn get_last_known_nonce_and_estimate(
     context: &RequestContext,
     chain_id: &str,
     safe_address: &str,
     safe_transaction_estimation_request: &SafeTransactionEstimationRequest,
-) -> ApiResult<SafeTransactionEstimation> {
+) -> ApiResult<(String, u64, Option<u64>)> {
     let info_provider = DefaultInfoProvider::new(chain_id, &context);
-    let estimation_url = core_uri!(
-        info_provider,
-        "/v1/safes/{}/multisig-transactions/estimations/",
-        safe_address
-    )?;
+
+    let current_nonce = info_provider.safe_info(safe_address).await?.nonce;
+
     let latest_multisig_tx_url = core_uri!(
         info_provider,
         "/v1/safes/{}/multisig-transactions/?ordering=-nonce&trusted=true&limit=1",
         safe_address
     )?;
-    let current_nonce = info_provider.safe_info(safe_address).await?.nonce;
+    let last_known_nonce =
+        fetch_last_known_nonce(context.http_client(), latest_multisig_tx_url).await?;
 
-    let latest_nonce = fetch_latest_nonce(context.http_client(), latest_multisig_tx_url).await?;
+    let estimation_url = core_uri!(
+        info_provider,
+        "/v1/safes/{}/multisig-transactions/estimations/",
+        safe_address
+    )?;
     let safe_tx_gas = fetch_estimation(
         context.http_client(),
         estimation_url,
@@ -39,9 +44,59 @@ pub async fn estimate_safe_tx_gas(
     )
     .await?;
 
+    Ok((safe_tx_gas, current_nonce, last_known_nonce))
+}
+
+pub async fn estimate_safe_tx_gas(
+    context: &RequestContext,
+    chain_id: &str,
+    safe_address: &str,
+    safe_transaction_estimation_request: &SafeTransactionEstimationRequest,
+) -> ApiResult<SafeTransactionEstimation> {
+    let (safe_tx_gas, current_nonce, last_known_nonce) = get_last_known_nonce_and_estimate(
+        context,
+        chain_id,
+        safe_address,
+        safe_transaction_estimation_request,
+    )
+    .await?;
+
+    // If there is no transaction available on the tx service, we default to 0
+    // Note: This is not really correct and therefore clients should use the recommended nonce returned
+    let latest_nonce = last_known_nonce.unwrap_or(0);
+
     Ok(SafeTransactionEstimation {
         current_nonce,
         latest_nonce,
+        safe_tx_gas,
+    })
+}
+
+pub async fn estimate_safe_tx_gas_v2(
+    context: &RequestContext,
+    chain_id: &str,
+    safe_address: &str,
+    safe_transaction_estimation_request: &SafeTransactionEstimationRequest,
+) -> ApiResult<SafeTransactionEstimationV2> {
+    let (safe_tx_gas, current_nonce, last_known_nonce) = get_last_known_nonce_and_estimate(
+        context,
+        chain_id,
+        safe_address,
+        safe_transaction_estimation_request,
+    )
+    .await?;
+
+    // The next nonce recommended to use for a new transaction is the maximum of
+    // - the nonce of the latest transaction from the tx service plus 1, or 0 if there is no such transaction
+    // - the current Safe nonce
+    let recommended_nonce = max(
+        current_nonce,
+        last_known_nonce.map(|it| it + 1).unwrap_or(0),
+    );
+
+    Ok(SafeTransactionEstimationV2 {
+        current_nonce,
+        recommended_nonce,
         safe_tx_gas,
     })
 }
@@ -66,7 +121,10 @@ async fn fetch_estimation(
     )
 }
 
-async fn fetch_latest_nonce(client: Arc<dyn HttpClient>, request_url: String) -> ApiResult<u64> {
+async fn fetch_last_known_nonce(
+    client: Arc<dyn HttpClient>,
+    request_url: String,
+) -> ApiResult<Option<u64>> {
     let request = Request::new(request_url);
     let latest_multisig_tx_response = client.get(request).await?;
     let nonce = serde_json::from_str::<Page<BackendMultisigTransaction>>(
@@ -74,8 +132,7 @@ async fn fetch_latest_nonce(client: Arc<dyn HttpClient>, request_url: String) ->
     )?
     .results
     .first()
-    .map(|it| it.nonce)
-    .unwrap_or(0);
+    .map(|it| it.nonce);
 
     Ok(nonce)
 }

--- a/src/routes/safes/models.rs
+++ b/src/routes/safes/models.rs
@@ -71,3 +71,12 @@ pub struct SafeTransactionEstimation {
     pub latest_nonce: u64,
     pub safe_tx_gas: String,
 }
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(Deserialize, PartialEq))]
+pub struct SafeTransactionEstimationV2 {
+    pub current_nonce: u64,
+    pub recommended_nonce: u64,
+    pub safe_tx_gas: String,
+}

--- a/src/routes/safes/routes.rs
+++ b/src/routes/safes/routes.rs
@@ -45,6 +45,7 @@ pub async fn get_owners(
 }
 
 /**
+ * DEPRECATED
  * `/v1/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations` <br />
  * Returns [SafeTransactionEstimation](crate::routes::safes::models::SafeTransactionEstimation)
  *
@@ -132,6 +133,7 @@ pub async fn post_safe_gas_estimation<'e>(
  *
  * ```json
  * {
+ *   "currentNonce": 7,
  *   "recommendedNonce": 76,
  *   "safeTxGas": "63417"
  * }

--- a/src/routes/safes/routes.rs
+++ b/src/routes/safes/routes.rs
@@ -104,7 +104,7 @@ pub async fn post_safe_gas_estimation<'e>(
 
 /**
  * `/v2/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations` <br />
- * Returns [SafeTransactionEstimation](crate::routes::safes::models::SafeTransactionEstimation)
+ * Returns [SafeTransactionEstimationV2](crate::routes::safes::models::SafeTransactionEstimationV2)
  *
  * # Safe Transaction Estimations
  *
@@ -134,7 +134,7 @@ pub async fn post_safe_gas_estimation<'e>(
  * ```json
  * {
  *   "currentNonce": 7,
- *   "recommendedNonce": 76,
+ *   "recommendedNonce": 77,
  *   "safeTxGas": "63417"
  * }
  * ```

--- a/src/routes/safes/routes.rs
+++ b/src/routes/safes/routes.rs
@@ -100,3 +100,62 @@ pub async fn post_safe_gas_estimation<'e>(
         .await?,
     )?))
 }
+
+/**
+ * `/v2/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations` <br />
+ * Returns [SafeTransactionEstimation](crate::routes::safes::models::SafeTransactionEstimation)
+ *
+ * # Safe Transaction Estimations
+ *
+ * This endpoint provides a `safeTxGas` according to the transaction passed as part of the request body,
+ * the `currentNonce` indicating what the nonce of the Safe currently is,
+ * and a `recommendedNonce` that should be used for the new transaction.
+ *
+ * ## Path
+ *
+ * - `/v2/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations
+ *
+ * ## Examples
+ *
+ * Example request body:
+ *
+ * ```json
+ * {
+ *   "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+ *   "value": "0",
+ *   "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+ *   "operation": 0
+ * }
+ * ```
+ *
+ * This results (at the time of writing this documentation) in:
+ *
+ * ```json
+ * {
+ *   "recommendedNonce": 76,
+ *   "safeTxGas": "63417"
+ * }
+ * ```
+ *
+ */
+#[post(
+    "/v2/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations",
+    format = "application/json",
+    data = "<safe_transaction_estimation_request>"
+)]
+pub async fn post_safe_gas_estimation_v2<'e>(
+    context: RequestContext,
+    chain_id: String,
+    safe_address: String,
+    safe_transaction_estimation_request: Result<Json<SafeTransactionEstimationRequest>, Error<'e>>,
+) -> ApiResult<content::Json<String>> {
+    Ok(content::Json(serde_json::to_string(
+        &estimations::estimate_safe_tx_gas_v2(
+            &context,
+            &chain_id,
+            &safe_address,
+            &safe_transaction_estimation_request?.0,
+        )
+        .await?,
+    )?))
+}

--- a/src/routes/safes/tests/routes.rs
+++ b/src/routes/safes/tests/routes.rs
@@ -5,6 +5,7 @@ use crate::config::{
 };
 use crate::routes::safes::models::{
     SafeState, SafeTransactionEstimation, SafeTransactionEstimationRequest,
+    SafeTransactionEstimationV2,
 };
 use crate::tests::main::setup_rocket;
 use crate::utils::errors::{ApiError, ErrorDetails};
@@ -926,6 +927,600 @@ async fn post_safe_gas_estimation_safe_error() {
 
     let request = client
         .post("/v1/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2() {
+    let safe_address = "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let request_last_queued_tx = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        ?ordering=-nonce\
+        &trusted=true\
+        &limit=1",
+        safe_address,
+    ));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(request_last_queued_tx))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(super::LAST_QUEUED_TX),
+                status_code: 200,
+            })
+        });
+
+    let mut estimation_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        estimations/",
+        &safe_address
+    ));
+    estimation_request.body(Some(serde_json::to_string(
+        &SafeTransactionEstimationRequest{
+            to: String::from("0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02"),
+            value: String::from("0"),
+            data: String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"),
+            operation: Operation::CALL
+            }).unwrap())
+        );
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(estimation_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: json!({
+                    "safeTxGas" : "63417"
+                })
+                .to_string(),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_GUARD_SAFE_V130_L2),
+                status_code: 200,
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let expected = serde_json::from_value(json!( {
+        "currentNonce": 7,
+        "recommendedNonce": 77,
+        "safeTxGas": "63417"
+    }))
+    .unwrap();
+
+    let request = client
+        .post("/v2/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    let actual_status = response.status();
+    let actual_json = response.into_string().await.unwrap();
+    let actual = serde_json::from_str::<SafeTransactionEstimationV2>(&actual_json).unwrap();
+
+    assert_eq!(actual_status, Status::Ok);
+    assert_eq!(actual, expected);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2_no_queued_tx() {
+    let safe_address = "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let request_last_queued_tx = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        ?ordering=-nonce\
+        &trusted=true\
+        &limit=1",
+        safe_address,
+    ));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(request_last_queued_tx))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::EMPTY_PAGE),
+                status_code: 200,
+            })
+        });
+
+    let mut estimation_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        estimations/",
+        &safe_address
+    ));
+    estimation_request.body(Some(serde_json::to_string(
+        &SafeTransactionEstimationRequest{
+            to: String::from("0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02"),
+            value: String::from("0"),
+            data: String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"),
+            operation: Operation::CALL
+            }).unwrap())
+        );
+
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(estimation_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: json!({
+                    "safeTxGas" : "63417"
+                })
+                .to_string(),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_GUARD_SAFE_V130_L2),
+                status_code: 200,
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let expected = serde_json::from_value(json!( {
+        "currentNonce": 7,
+        "recommendedNonce": 7,
+        "safeTxGas": "63417"
+    }))
+    .unwrap();
+
+    let request = client
+        .post("/v2/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    let actual_status = response.status();
+    let actual_json = response.into_string().await.unwrap();
+    let actual = serde_json::from_str::<SafeTransactionEstimationV2>(&actual_json).unwrap();
+
+    assert_eq!(actual_status, Status::Ok);
+    assert_eq!(actual, expected);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2_delayed_indexing() {
+    let safe_address = "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let request_last_known_tx = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        ?ordering=-nonce\
+        &trusted=true\
+        &limit=1",
+        safe_address,
+    ));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(request_last_known_tx))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(super::LAST_HISTORY_TX),
+                status_code: 200,
+            })
+        });
+
+    let mut estimation_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        estimations/",
+        &safe_address
+    ));
+    estimation_request.body(Some(serde_json::to_string(
+        &SafeTransactionEstimationRequest{
+            to: String::from("0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02"),
+            value: String::from("0"),
+            data: String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"),
+            operation: Operation::CALL
+            }).unwrap())
+        );
+
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(estimation_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: json!({
+                    "safeTxGas" : "63417"
+                })
+                .to_string(),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_GUARD_SAFE_V130_L2),
+                status_code: 200,
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let expected = serde_json::from_value(json!( {
+        "currentNonce": 7,
+        "recommendedNonce": 7,
+        "safeTxGas": "63417"
+    }))
+    .unwrap();
+
+    let request = client
+        .post("/v2/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    let actual_status = response.status();
+    let actual_json = response.into_string().await.unwrap();
+    let actual = serde_json::from_str::<SafeTransactionEstimationV2>(&actual_json).unwrap();
+
+    assert_eq!(actual_status, Status::Ok);
+    assert_eq!(actual, expected);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2_estimation_error() {
+    let safe_address = "0xD6f5Bef6bb4acD235CF85c0ce196316d10785d67"; // not checksummed
+    let error_message = "{\"code\":1,\"message\":\"Checksum address validation failed\",/
+    \"arguments\":[\"0xd6f5Bef6bb4acd235CF85c0ce196316d10785d67\"]}";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let request_last_queued_tx = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        ?ordering=-nonce\
+        &trusted=true\
+        &limit=1",
+        safe_address,
+    ));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(request_last_queued_tx))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(super::LAST_QUEUED_TX),
+                status_code: 200,
+            })
+        });
+
+    let mut estimation_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        estimations/",
+        &safe_address
+    ));
+    estimation_request.body(Some(serde_json::to_string(
+        &SafeTransactionEstimationRequest{
+            to: String::from("0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02"),
+            value: String::from("0"),
+            data: String::from("0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"),
+            operation: Operation::CALL
+            }).unwrap())
+        );
+
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(estimation_request))
+        .return_once(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                status_code: 422,
+                body: String::from(error_message),
+            }))
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_GUARD_SAFE_V130_L2),
+                status_code: 200,
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let expected = ApiError::new_from_message_with_code(422, String::from(error_message));
+
+    let request = client
+        .post("/v2/chains/4/safes/0xD6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    let actual_status = response.status();
+    let actual_error_details =
+        serde_json::from_str::<ErrorDetails>(&response.into_string().await.unwrap()).unwrap();
+
+    assert_eq!(actual_status, Status::UnprocessableEntity);
+    assert_eq!(actual_error_details, expected.details);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2_nonce_error() {
+    let safe_address = "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let request_last_queued_tx = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/\
+        multisig-transactions/\
+        ?ordering=-nonce\
+        &trusted=true\
+        &limit=1",
+        safe_address,
+    ));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(request_last_queued_tx))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                body: String::new(),
+                status_code: 404,
+            }))
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::SAFE_WITH_GUARD_SAFE_V130_L2),
+                status_code: 200,
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let request = client
+        .post("/v2/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
+        .body(&json!({
+            "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
+            "value": "0",
+            "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
+            "operation": 0
+            }).to_string())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+#[rocket::async_test]
+async fn post_safe_gas_estimation_v2_safe_error() {
+    let safe_address = "0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67";
+
+    let mut chain_request = Request::new(config_uri!("/v1/chains/{}/", 4));
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    let mut mock_http_client = MockHttpClient::new();
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_RINKEBY),
+            })
+        });
+
+    let mut safe_request = Request::new(format!(
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/",
+        &safe_address
+    ));
+    safe_request.timeout(Duration::from_millis(safe_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(safe_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                body: String::new(),
+                status_code: 404,
+            }))
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_safe_gas_estimation_v2],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let request = client
+        .post("/v2/chains/4/safes/0xd6f5Bef6bb4acD235CF85c0ce196316d10785d67/multisig-transactions/estimations")
         .body(&json!({
             "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
             "value": "0",

--- a/src/routes/safes/tests/routes.rs
+++ b/src/routes/safes/tests/routes.rs
@@ -553,7 +553,7 @@ async fn post_safe_gas_estimation_no_queued_tx() {
 
     let expected = serde_json::from_value(json!( {
         "currentNonce": 7,
-        "latestNonce": 7,
+        "latestNonce": 0,
         "safeTxGas": "63417"
     }))
     .unwrap();
@@ -670,7 +670,7 @@ async fn post_safe_gas_estimation_delayed_indexing() {
 
     let expected = serde_json::from_value(json!( {
         "currentNonce": 7,
-        "latestNonce": 7,
+        "latestNonce": 6,
         "safeTxGas": "63417"
     }))
     .unwrap();


### PR DESCRIPTION
Closes #757 

- Revert #754 
- Add `v2` estimation endpoint that replaces `latestNonce` with `recommendedNonce`
 
Example:
Endpoint: `POST - /v2/chains/<chain_id>/safes/<safe_address>/multisig-transactions/estimations`

Example request body:
  ```json
  {
    "to": "0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02",
    "value": "0",
    "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
    "operation": 0
  }
 ```

Assuming the current nonce of the Safe is `7` and the transaction with the highest nonce stored on the service is `76` the following response will be returned:
 ```json
  {
    "currentNonce": 7,
    "recommendedNonce": 77,
    "safeTxGas": "63417"
  }
 ```

`recommendedNonce` can be directly used for proposing a new Safe transaction without further adjustments.