### PR TITLE
Map redis port to localhost:6379

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   redis:
     image: redis:6-alpine
     ports:
-      - "6379"
+      - "6379:6379"
 
   web:
     build:


### PR DESCRIPTION
- Map the `redis` port in `docker-compose.yml` to `localhost:6379`
- This makes it easier to deterministically check if `redis` is running on that port without having to check which port was mapped by Docker