### PR TITLE
Pagination fix for `chains` endpoint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,7 @@ jobs:
       WEBHOOK_TOKEN: test_webhook_token
       CONFIG_SERVICE_URI: https://config.service.url
       VPC_TRANSACTION_SERVICE_URI: 'false'
+      SCHEME: http
 
     steps:
       - name: Checkout branch

--- a/src/common/converters/page_metadata.rs
+++ b/src/common/converters/page_metadata.rs
@@ -7,10 +7,7 @@ impl PageMetadata {
     }
 
     pub fn from_cursor(encoded_cursor: &str) -> Self {
-        let mut output = Self {
-            offset: 0,
-            limit: 20,
-        };
+        let mut output = Self::default();
 
         let chunked: Vec<Vec<&str>> = encoded_cursor
             .split("&")
@@ -27,5 +24,13 @@ impl PageMetadata {
         });
 
         output
+    }
+}
+impl Default for PageMetadata {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            limit: 20,
+        }
     }
 }

--- a/src/common/models/page.rs
+++ b/src/common/models/page.rs
@@ -21,13 +21,13 @@ pub struct SafeList {
 }
 
 impl<T> Page<T> {
-    pub fn map_inner<U>(self) -> Page<U>
+    pub fn map_inner<U>(self, link_mapper: impl Fn(Option<String>) -> Option<String>) -> Page<U>
     where
         U: From<T>,
     {
         Page {
-            next: self.next,
-            previous: self.previous,
+            next: link_mapper(self.next),
+            previous: link_mapper(self.previous),
             results: self.results.into_iter().map(|it| U::from(it)).collect(),
         }
     }

--- a/src/common/models/page.rs
+++ b/src/common/models/page.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Page<T> {
     pub next: Option<String>,
     pub previous: Option<String>,

--- a/src/routes/chains/handlers.rs
+++ b/src/routes/chains/handlers.rs
@@ -43,7 +43,7 @@ pub async fn get_single_chain(
 }
 
 fn map_link(context: &RequestContext, original_link: Option<String>) -> Option<String> {
-    let a = original_link.as_ref().map(|link| {
+    original_link.as_ref().map(|link| {
         let cursor =
             PageMetadata::from_cursor(link.split("?").collect::<Vec<&str>>().get(1).unwrap_or(&""))
                 .to_url_string();
@@ -52,6 +52,5 @@ fn map_link(context: &RequestContext, original_link: Option<String>) -> Option<S
             uri!(crate::routes::chains::routes::get_chains(Some(cursor))),
         );
         String::from(uri)
-    });
-    a
+    })
 }

--- a/src/routes/chains/handlers.rs
+++ b/src/routes/chains/handlers.rs
@@ -45,7 +45,8 @@ pub async fn get_single_chain(
 fn map_link(context: &RequestContext, original_link: Option<String>) -> Option<String> {
     let a = original_link.as_ref().map(|link| {
         let cursor =
-            PageMetadata::from_cursor(link.split("?").collect::<Vec<&str>>()[1]).to_url_string();
+            PageMetadata::from_cursor(link.split("?").collect::<Vec<&str>>().get(1).unwrap_or(&""))
+                .to_url_string();
         let uri = build_absolute_uri(
             context,
             uri!(crate::routes::chains::routes::get_chains(Some(cursor))),

--- a/src/routes/chains/handlers.rs
+++ b/src/routes/chains/handlers.rs
@@ -1,6 +1,6 @@
 use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::chains::ChainInfo as BackendChainInfo;
-use crate::common::models::page::{Page, PageMetadata};
+use crate::common::models::page::Page;
 use crate::config::{chain_info_cache_duration, chain_info_request_timeout};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::chains::models::ChainInfo as ServiceChainInfo;
@@ -36,5 +36,9 @@ pub async fn get_single_chain(
 }
 
 fn map_link(original_link: Option<String>) -> Option<String> {
-    original_link
+    let a = original_link.as_ref().map(|link| {
+        log::error!("URLS CONFIG: {}", link);
+        String::from(link)
+    });
+    a.to_owned()
 }

--- a/src/routes/chains/handlers.rs
+++ b/src/routes/chains/handlers.rs
@@ -1,6 +1,6 @@
 use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::chains::ChainInfo as BackendChainInfo;
-use crate::common::models::page::Page;
+use crate::common::models::page::{Page, PageMetadata};
 use crate::config::{chain_info_cache_duration, chain_info_request_timeout};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::chains::models::ChainInfo as ServiceChainInfo;
@@ -23,7 +23,8 @@ pub async fn get_chains_paginated(
         .await?;
 
     let page = serde_json::from_str::<Page<BackendChainInfo>>(&body)?;
-    Ok(page.map_inner())
+
+    Ok(page.map_inner(map_link))
 }
 
 pub async fn get_single_chain(
@@ -32,4 +33,8 @@ pub async fn get_single_chain(
 ) -> ApiResult<ServiceChainInfo> {
     let info_provider = DefaultInfoProvider::new(&chain_id, &context);
     Ok(info_provider.chain_info().await?.into())
+}
+
+fn map_link(original_link: Option<String>) -> Option<String> {
+    original_link
 }

--- a/src/routes/chains/handlers.rs
+++ b/src/routes/chains/handlers.rs
@@ -44,7 +44,8 @@ pub async fn get_single_chain(
 
 fn map_link(context: &RequestContext, original_link: Option<String>) -> Option<String> {
     let a = original_link.as_ref().map(|link| {
-        let cursor = link.split("?").collect::<Vec<&str>>()[1];
+        let cursor =
+            PageMetadata::from_cursor(link.split("?").collect::<Vec<&str>>()[1]).to_url_string();
         let uri = build_absolute_uri(
             context,
             uri!(crate::routes::chains::routes::get_chains(Some(cursor))),

--- a/src/routes/chains/models.rs
+++ b/src/routes/chains/models.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub struct ChainInfo {
     pub transaction_service: String,
     // do we need to expose this?
@@ -25,6 +26,7 @@ pub struct ChainInfo {
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub struct NativeCurrency {
     pub name: String,
     pub symbol: String,
@@ -34,6 +36,7 @@ pub struct NativeCurrency {
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub struct Theme {
     pub text_color: String,
     pub background_color: String,
@@ -42,6 +45,7 @@ pub struct Theme {
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub enum GasPrice {
     #[serde(rename_all = "camelCase")]
     Oracle {
@@ -58,6 +62,7 @@ pub enum GasPrice {
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub struct RpcUri {
     pub authentication: RpcAuthentication,
     pub value: String,
@@ -65,6 +70,7 @@ pub struct RpcUri {
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub enum RpcAuthentication {
     ApiKeyPath,
     NoAuthentication,
@@ -74,6 +80,7 @@ pub enum RpcAuthentication {
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub struct BlockExplorerUriTemplate {
     pub address: String,
     pub tx_hash: String,

--- a/src/routes/chains/routes.rs
+++ b/src/routes/chains/routes.rs
@@ -43,14 +43,14 @@ pub async fn get_chain(
  * - `/v1/chains/` Returns the `ChainInfo` for our services supported networks
  *
  */
-#[get("/v1/chains?<limit>")]
+#[get("/v1/chains?<cursor>")]
 pub async fn get_chains(
     context: RequestContext,
-    limit: Option<String>,
+    cursor: Option<String>,
 ) -> ApiResult<content::Json<String>> {
     CacheResponse::new(&context)
         .duration(chain_info_response_cache_duration())
-        .resp_generator(|| get_chains_paginated(&context, &limit))
+        .resp_generator(|| get_chains_paginated(&context, &cursor))
         .execute()
         .await
 }

--- a/src/routes/chains/tests/json/backend_chains_info_page.json
+++ b/src/routes/chains/tests/json/backend_chains_info_page.json
@@ -1,0 +1,73 @@
+{
+    "count": 3,
+    "next": "https://safe-config.staging.gnosisdev.com/api/v1/chains/?limit=1&offset=2",
+    "previous": "https://safe-config.staging.gnosisdev.com/api/v1/chains/?limit=1",
+    "results": [
+        {
+            "chainId": "137",
+            "chainName": "Polygon",
+            "shortName": "matic",
+            "description": "Test",
+            "l2": true,
+            "rpcUri": {
+                "authentication": "API_KEY_PATH",
+                "value": "https://polygon-mainnet.infura.io/v3/"
+            },
+            "safeAppsRpcUri": {
+                "authentication": "API_KEY_PATH",
+                "value": "https://polygon-mainnet.infura.io/v3/"
+            },
+            "publicRpcUri": {
+                "authentication": "NO_AUTHENTICATION",
+                "value": "https://polygon-rpc.com/"
+            },
+            "blockExplorerUriTemplate": {
+                "address": "https://polygonscan.com/address/{{address}}",
+                "txHash": "https://polygonscan.com/tx/{{txHash}}",
+                "api": "https://api.polygonscan.com/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+            },
+            "nativeCurrency": {
+                "name": "Matic",
+                "symbol": "MATIC",
+                "decimals": 18,
+                "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/137/currency_logo.png"
+            },
+            "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",
+            "vpcTransactionService": "http://staging-polygon-safe-transaction-web.safe.svc.cluster.local",
+            "theme": {
+                "textColor": "#ffffff",
+                "backgroundColor": "#8248E5"
+            },
+            "gasPrice": [
+                {
+                    "type": "oracle",
+                    "uri": "https://gasstation-mainnet.matic.network",
+                    "gasParameter": "standard",
+                    "gweiFactor": "1000000000.000000000"
+                }
+            ],
+            "ensRegistryAddress": null,
+            "recommendedMasterCopyVersion": "1.3.0",
+            "disabledWallets": [
+                "authereum",
+                "coinbase",
+                "fortmatic",
+                "keystone",
+                "lattice",
+                "opera",
+                "operaTouch",
+                "portis",
+                "torus",
+                "trezor",
+                "trust",
+                "walletLink"
+            ],
+            "features": [
+                "CONTRACT_INTERACTION",
+                "ERC721",
+                "SAFE_APPS",
+                "SAFE_TX_GAS_OPTIONAL"
+            ]
+        }
+    ]
+}

--- a/src/routes/chains/tests/json/expected_chains_info_page.json
+++ b/src/routes/chains/tests/json/expected_chains_info_page.json
@@ -1,0 +1,69 @@
+{
+    "next": "http://test.gnosis.io/api/v1/chains?cursor=limit%3D1%26offset%3D2",
+    "previous": "http://test.gnosis.io/api/v1/chains?cursor=limit%3D1%26offset%3D0",
+    "results": [
+        {
+            "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",
+            "chainId": "137",
+            "chainName": "Polygon",
+            "shortName": "matic",
+            "l2": true,
+            "description": "Test",
+            "rpcUri": {
+                "authentication": "API_KEY_PATH",
+                "value": "https://polygon-mainnet.infura.io/v3/"
+            },
+            "safeAppsRpcUri": {
+                "authentication": "API_KEY_PATH",
+                "value": "https://polygon-mainnet.infura.io/v3/"
+            },
+            "publicRpcUri": {
+                "authentication": "NO_AUTHENTICATION",
+                "value": "https://polygon-rpc.com/"
+            },
+            "blockExplorerUriTemplate": {
+                "address": "https://polygonscan.com/address/{{address}}",
+                "txHash": "https://polygonscan.com/tx/{{txHash}}",
+                "api": "https://api.polygonscan.com/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+            },
+            "nativeCurrency": {
+                "name": "Matic",
+                "symbol": "MATIC",
+                "decimals": 18,
+                "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/137/currency_logo.png"
+            },
+            "theme": {
+                "textColor": "#ffffff",
+                "backgroundColor": "#8248E5"
+            },
+            "gasPrice": [
+                {
+                    "type": "ORACLE",
+                    "uri": "https://gasstation-mainnet.matic.network",
+                    "gasParameter": "standard",
+                    "gweiFactor": "1000000000.000000000"
+                }
+            ],
+            "disabledWallets": [
+                "authereum",
+                "coinbase",
+                "fortmatic",
+                "keystone",
+                "lattice",
+                "opera",
+                "operaTouch",
+                "portis",
+                "torus",
+                "trezor",
+                "trust",
+                "walletLink"
+            ],
+            "features": [
+                "CONTRACT_INTERACTION",
+                "ERC721",
+                "SAFE_APPS",
+                "SAFE_TX_GAS_OPTIONAL"
+            ]
+        }
+    ]
+}

--- a/src/routes/chains/tests/mod.rs
+++ b/src/routes/chains/tests/mod.rs
@@ -1,1 +1,7 @@
 mod chains;
+mod routes;
+
+pub(super) const BACKEND_CHAINS_INFO_PAGE: &str =
+    include_str!("json/backend_chains_info_page.json");
+pub(super) const EXPECTED_CHAINS_INFO_PAGE: &str =
+    include_str!("json/expected_chains_info_page.json");

--- a/src/routes/chains/tests/routes.rs
+++ b/src/routes/chains/tests/routes.rs
@@ -1,0 +1,54 @@
+use crate::{
+    common::models::page::Page,
+    config::chain_info_request_timeout,
+    routes::chains::models::ChainInfo,
+    tests::main::setup_rocket,
+    utils::http_client::{MockHttpClient, Request, Response},
+};
+use mockall::predicate::eq;
+use rocket::http::{ContentType, Header, Status};
+use rocket::local::asynchronous::Client;
+
+use std::time::Duration;
+
+#[rocket::async_test]
+async fn paginated_chain_infos() {
+    let request_uri = config_uri!("/v1/chains/?limit=1&offset=1");
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut chain_request = Request::new(request_uri.clone());
+    chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(chain_request))
+        .returning(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(super::BACKEND_CHAINS_INFO_PAGE),
+            })
+        });
+
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::get_chains],
+    ))
+    .await
+    .expect("valid rocket instance");
+    let expected =
+        serde_json::from_str::<Page<ChainInfo>>(super::EXPECTED_CHAINS_INFO_PAGE).unwrap();
+
+    let request = client
+        .get("/v1/chains?cursor=limit%3D1%26offset%3D1")
+        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(ContentType::JSON);
+
+    let response = request.dispatch().await;
+
+    let actual_status = response.status();
+    let actual_json_body = response.into_string().await.unwrap();
+    let actual = serde_json::from_str::<Page<ChainInfo>>(&actual_json_body).unwrap();
+
+    assert_eq!(actual_status, Status::Ok);
+    assert_eq!(actual, expected);
+}

--- a/src/routes/transactions/handlers/history.rs
+++ b/src/routes/transactions/handlers/history.rs
@@ -5,12 +5,13 @@ use crate::common::models::backend::transactions::{CreationTransaction, Transact
 use crate::common::models::page::{Page, PageMetadata};
 use crate::config::transaction_request_timeout;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
-use crate::routes::transactions::handlers::{build_absolute_uri, offset_page_meta};
+use crate::routes::transactions::handlers::offset_page_meta;
 use crate::routes::transactions::models::summary::{
     ConflictType, TransactionListItem, TransactionSummary,
 };
 use crate::utils::context::RequestContext;
 use crate::utils::errors::ApiResult;
+use crate::utils::urls::build_absolute_uri;
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, Utc};
 use itertools::Itertools;
 

--- a/src/routes/transactions/handlers/mod.rs
+++ b/src/routes/transactions/handlers/mod.rs
@@ -18,7 +18,3 @@ pub(super) fn offset_page_meta(meta: &PageMetadata, offset: i64) -> String {
     }
     .to_url_string()
 }
-
-pub(super) fn build_absolute_uri(context: &RequestContext, origin: Origin) -> String {
-    format!("{}{}", context.host, origin)
-}

--- a/src/routes/transactions/handlers/mod.rs
+++ b/src/routes/transactions/handlers/mod.rs
@@ -1,6 +1,4 @@
 use crate::common::models::page::PageMetadata;
-use crate::utils::context::RequestContext;
-use rocket::http::uri::Origin;
 use std::cmp::max;
 
 pub mod details;

--- a/src/routes/transactions/handlers/queued.rs
+++ b/src/routes/transactions/handlers/queued.rs
@@ -3,10 +3,11 @@ use crate::common::models::backend::transactions::MultisigTransaction;
 use crate::common::models::page::{Page, PageMetadata};
 use crate::config::transaction_request_timeout;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
-use crate::routes::transactions::handlers::{build_absolute_uri, offset_page_meta};
+use crate::routes::transactions::handlers::offset_page_meta;
 use crate::routes::transactions::models::summary::{ConflictType, Label, TransactionListItem};
 use crate::utils::context::RequestContext;
 use crate::utils::errors::ApiResult;
+use crate::utils::urls::build_absolute_uri;
 use itertools::Itertools;
 use std::collections::HashMap;
 

--- a/src/utils/urls.rs
+++ b/src/utils/urls.rs
@@ -2,6 +2,9 @@ use crate::utils::errors::ApiResult;
 use lazy_static::lazy_static;
 use regex::Regex;
 use reqwest::Url;
+use rocket::http::uri::Origin;
+
+use super::context::RequestContext;
 
 lazy_static! {
     static ref IP_ADDRESS: Regex = Regex::new(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}").unwrap();
@@ -27,4 +30,8 @@ pub fn build_manifest_url(url: &str) -> ApiResult<String> {
         url_parts.set_query(None);
         Ok(url_parts.to_string())
     }
+}
+
+pub fn build_absolute_uri(context: &RequestContext, origin: Origin) -> String {
+    format!("{}{}", context.host, origin)
 }


### PR DESCRIPTION
Closes #762 

- We bundle `limit` and `offset` in `cursor` to generate the `next` and `previous` links for `Page`s of data (like for tx related endpoints)
- Reused as much code as possible from `txHistory` and `txQueued`
- Tested `chain` endpoints
