### PR TITLE
Added `TRANSACTION_SERVICE_AUTH_TOKEN` and the possibility to add headers to requests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,7 +17,7 @@ ROCKET_ADDRESS=127.0.0.1
 # ROCKET_PORT=8000
 # ROCKET_ADDRESS=localhost
 WEBHOOK_TOKEN=some_random_token
-CORE_SERVICE_AUTH_TOKEN=some_other_random_token
+TRANSACTION_SERVICE_AUTH_TOKEN=some_other_random_token
 # Rocket logs are noise-y, this value filters the logs for errors and our perf monitor
 # Set to "debug" when developing
 # You can select which proportion of the time logs are emited with LOG_THRESHOLD values range [0.0, 1.0]

--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,7 @@ ROCKET_ADDRESS=127.0.0.1
 # ROCKET_PORT=8000
 # ROCKET_ADDRESS=localhost
 WEBHOOK_TOKEN=some_random_token
+CORE_SERVICE_AUTH_TOKEN=some_other_random_token
 # Rocket logs are noise-y, this value filters the logs for errors and our perf monitor
 # Set to "debug" when developing
 # You can select which proportion of the time logs are emited with LOG_THRESHOLD values range [0.0, 1.0]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,7 @@ jobs:
       WEBHOOK_TOKEN: test_webhook_token
       CONFIG_SERVICE_URI: https://config.service.url
       VPC_TRANSACTION_SERVICE_URI: 'false'
+      CORE_SERVICE_AUTH_TOKEN: some_other_random_token
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
       WEBHOOK_TOKEN: test_webhook_token
       CONFIG_SERVICE_URI: https://config.service.url
       VPC_TRANSACTION_SERVICE_URI: 'false'
-      CORE_SERVICE_AUTH_TOKEN: some_other_random_token
+      TRANSACTION_SERVICE_AUTH_TOKEN: some_other_random_token
 
     steps:
       - name: Checkout branch

--- a/src/cache/cache_op_executors.rs
+++ b/src/cache/cache_op_executors.rs
@@ -41,6 +41,9 @@ pub(super) async fn request_cached(operation: &RequestCached) -> ApiResult<Strin
             let http_request = {
                 let mut request = Request::new(String::from(&operation.url));
                 request.timeout(Duration::from_millis(operation.request_timeout));
+                for (header, value) in &operation.headers {
+                    request.add_header((header, value));
+                }
                 request
             };
             let response = client.get(http_request).await;

--- a/src/cache/cache_operations.rs
+++ b/src/cache/cache_operations.rs
@@ -13,6 +13,7 @@ use rocket::futures::FutureExt;
 use rocket::response::content;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 
@@ -155,6 +156,7 @@ pub struct RequestCached {
     pub cache_duration: usize,
     pub error_cache_duration: usize,
     pub cache_all_errors: bool,
+    pub headers: HashMap<String, String>,
 }
 
 impl RequestCached {
@@ -167,6 +169,7 @@ impl RequestCached {
             cache_duration: request_cache_duration(),
             error_cache_duration: request_error_cache_duration(),
             cache_all_errors: false,
+            headers: HashMap::new(),
         }
     }
 
@@ -179,6 +182,7 @@ impl RequestCached {
             cache_duration: request_cache_duration(),
             error_cache_duration: request_error_cache_duration(),
             cache_all_errors: false,
+            headers: HashMap::new(),
         }
     }
 
@@ -199,6 +203,12 @@ impl RequestCached {
 
     pub fn cache_all_errors(&mut self) -> &mut Self {
         self.cache_all_errors = true;
+        self
+    }
+
+    pub fn add_header(&mut self, header: (&str, &str)) -> &mut Self {
+        self.headers
+            .insert(String::from(header.0), String::from(header.1));
         self
     }
 

--- a/src/cache/cache_operations.rs
+++ b/src/cache/cache_operations.rs
@@ -169,7 +169,7 @@ impl RequestCached {
             cache_duration: request_cache_duration(),
             error_cache_duration: request_error_cache_duration(),
             cache_all_errors: false,
-            headers: HashMap::new(),
+            headers: HashMap::default(),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,12 @@ pub fn webhook_token() -> String {
     env::var("WEBHOOK_TOKEN").expect("WEBHOOK_TOKEN missing in env")
 }
 
+pub fn core_services_auth_token() -> String {
+    let token =
+        env::var("CORE_SERVICE_AUTH_TOKEN").expect("CORE_SERVICE_AUTH_TOKEN missing in env");
+    format!("Token {}", token)
+}
+
 pub fn scheme() -> String {
     env_with_default("SCHEME", "https".into())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,8 +29,8 @@ pub fn webhook_token() -> String {
 }
 
 pub fn transaction_service_auth_token() -> String {
-    let token =
-        env::var("TRANSACTION_SERVICE_AUTH_TOKEN").expect("CORE_SERVICE_AUTH_TOKEN missing in env");
+    let token = env::var("TRANSACTION_SERVICE_AUTH_TOKEN")
+        .expect("TRANSACTION_SERVICE_AUTH_TOKEN missing in env");
     format!("Token {}", token)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,9 +28,9 @@ pub fn webhook_token() -> String {
     env::var("WEBHOOK_TOKEN").expect("WEBHOOK_TOKEN missing in env")
 }
 
-pub fn core_services_auth_token() -> String {
+pub fn transaction_service_auth_token() -> String {
     let token =
-        env::var("CORE_SERVICE_AUTH_TOKEN").expect("CORE_SERVICE_AUTH_TOKEN missing in env");
+        env::var("TRANSACTION_SERVICE_AUTH_TOKEN").expect("CORE_SERVICE_AUTH_TOKEN missing in env");
     format!("Token {}", token)
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,8 +29,10 @@ pub fn webhook_token() -> String {
 }
 
 pub fn transaction_service_auth_token() -> String {
-    let token = env::var("TRANSACTION_SERVICE_AUTH_TOKEN")
-        .expect("TRANSACTION_SERVICE_AUTH_TOKEN missing in env");
+    let token = env::var("TRANSACTION_SERVICE_AUTH_TOKEN").unwrap_or_else(|_| {
+        log::warn!("TRANSACTION_SERVICE_AUTH_TOKEN missing in env");
+        String::new()
+    });
     format!("Token {}", token)
 }
 

--- a/src/routes/safes/handlers/safes.rs
+++ b/src/routes/safes/handlers/safes.rs
@@ -2,7 +2,9 @@ use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::transactions::{MultisigTransaction, Transaction};
 use crate::common::models::backend::transfers::Transfer;
 use crate::common::models::page::{Page, SafeList};
-use crate::config::{owners_for_safes_cache_duration, transaction_request_timeout};
+use crate::config::{
+    core_services_auth_token, owners_for_safes_cache_duration, transaction_request_timeout,
+};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::safes::models::{SafeLastChanges, SafeState};
 use crate::utils::context::RequestContext;
@@ -151,6 +153,7 @@ pub async fn get_owners_for_safe(
     let url = core_uri!(info_provider, "/v1/owners/{}/safes/", owner_address)?;
     let body = RequestCached::new_from_context(url, context)
         .cache_duration(owners_for_safes_cache_duration())
+        .add_header(("Authorization", &core_services_auth_token()))
         .execute()
         .await?;
 

--- a/src/routes/safes/handlers/safes.rs
+++ b/src/routes/safes/handlers/safes.rs
@@ -3,7 +3,7 @@ use crate::common::models::backend::transactions::{MultisigTransaction, Transact
 use crate::common::models::backend::transfers::Transfer;
 use crate::common::models::page::{Page, SafeList};
 use crate::config::{
-    core_services_auth_token, owners_for_safes_cache_duration, transaction_request_timeout,
+    owners_for_safes_cache_duration, transaction_request_timeout, transaction_service_auth_token,
 };
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::safes::models::{SafeLastChanges, SafeState};
@@ -153,7 +153,7 @@ pub async fn get_owners_for_safe(
     let url = core_uri!(info_provider, "/v1/owners/{}/safes/", owner_address)?;
     let body = RequestCached::new_from_context(url, context)
         .cache_duration(owners_for_safes_cache_duration())
-        .add_header(("Authorization", &core_services_auth_token()))
+        .add_header(("Authorization", &transaction_service_auth_token()))
         .execute()
         .await?;
 

--- a/src/routes/safes/tests/routes.rs
+++ b/src/routes/safes/tests/routes.rs
@@ -250,10 +250,11 @@ async fn get_owners() {
             })
         });
 
-    let safe_request = Request::new(format!(
+    let mut safe_request = Request::new(format!(
         "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/owners/{}/safes/",
         &safe_address
     ));
+    safe_request.add_header(("Authorization", "Token some_other_random_token"));
     mock_http_client
         .expect_get()
         .times(1)
@@ -310,10 +311,11 @@ async fn get_owners_not_found() {
             })
         });
 
-    let safe_request = Request::new(format!(
+    let mut safe_request = Request::new(format!(
         "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/owners/{}/safes/",
         &safe_address
     ));
+    safe_request.add_header(("Authorization", "Token some_other_random_token"));
     mock_http_client
         .expect_get()
         .times(1)

--- a/src/utils/http_client.rs
+++ b/src/utils/http_client.rs
@@ -21,7 +21,7 @@ impl Request {
             url,
             body: None,
             timeout: Duration::from_millis(default_request_timeout()),
-            headers: HashMap::new(),
+            headers: HashMap::default(),
         }
     }
 

--- a/src/utils/http_client.rs
+++ b/src/utils/http_client.rs
@@ -4,7 +4,7 @@ use crate::config::internal_client_connect_timeout;
 use crate::utils::errors::{ApiError, ApiResult};
 use core::time::Duration;
 use mockall::automock;
-use reqwest::{header::CONTENT_TYPE, RequestBuilder};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug)]
@@ -96,7 +96,7 @@ impl HttpClient for reqwest::Client {
         let response = self
             .get(&request.url)
             .timeout(request.timeout)
-            // .headers(request.headers)
+            .headers(map_headers(&request.headers))
             .send()
             .await?;
         Response::from(response).await
@@ -108,6 +108,7 @@ impl HttpClient for reqwest::Client {
             .post(&request.url)
             .header(CONTENT_TYPE, "application/json")
             .body(body)
+            .headers(map_headers(&request.headers))
             .timeout(request.timeout)
             .send()
             .await?;
@@ -120,11 +121,24 @@ impl HttpClient for reqwest::Client {
             .delete(&request.url)
             .header(CONTENT_TYPE, "application/json")
             .body(body)
+            .headers(map_headers(&request.headers))
             .timeout(request.timeout)
             .send()
             .await?;
         Response::from(response).await
     }
+}
+
+fn map_headers(headers_input: &HashMap<String, String>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in headers_input {
+        headers.insert(
+            HeaderName::from_bytes(name.as_bytes())
+                .expect(&format!("Header name '{}' is not supported", &name)),
+            HeaderValue::from_str(value).expect(&format!("Invalid header value for '{}'", &name)),
+        );
+    }
+    headers
 }
 
 #[cfg(test)]

--- a/src/utils/http_client.rs
+++ b/src/utils/http_client.rs
@@ -4,13 +4,15 @@ use crate::config::internal_client_connect_timeout;
 use crate::utils::errors::{ApiError, ApiResult};
 use core::time::Duration;
 use mockall::automock;
-use reqwest::header::CONTENT_TYPE;
+use reqwest::{header::CONTENT_TYPE, RequestBuilder};
+use std::collections::HashMap;
 
 #[derive(PartialEq, Debug)]
 pub struct Request {
     url: String,
     body: Option<String>,
     timeout: Duration,
+    headers: HashMap<String, String>,
 }
 
 impl Request {
@@ -19,6 +21,7 @@ impl Request {
             url,
             body: None,
             timeout: Duration::from_millis(default_request_timeout()),
+            headers: HashMap::new(),
         }
     }
 
@@ -29,6 +32,12 @@ impl Request {
 
     pub fn body(&mut self, body: Option<String>) -> &mut Self {
         self.body = body;
+        self
+    }
+
+    pub fn add_header(&mut self, header: (&str, &str)) -> &mut Self {
+        self.headers
+            .insert(String::from(header.0), String::from(header.1));
         self
     }
 }
@@ -87,6 +96,7 @@ impl HttpClient for reqwest::Client {
         let response = self
             .get(&request.url)
             .timeout(request.timeout)
+            // .headers(request.headers)
             .send()
             .await?;
         Response::from(response).await


### PR DESCRIPTION
Closes #772 

Note: ~~`TRANSACTION_SERVICE_AUTH_TOKEN` is now **expected** . Meaning that if not present, the CGW would panic, failing the request.~~

The env var has been made optional as it is not an integral part of the setup of a CGW instance. However, I left the original error mesasge as a `WARN` level log, to notify developers.