### PR TITLE
Bump service version to 3.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "3.14.0"
+version = "3.15.0"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Changelog: https://github.com/gnosis/safe-client-gateway/compare/v3.14.0...bump-safe-config-version