### PR TITLE
Bump rust from 1.56.0 to 1.58.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.58.0"


### PR DESCRIPTION
- 1.58.0 Release – https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html
- 1.57.0 Release – https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html